### PR TITLE
docs: add Voice, Conversations, WFM and complete Custom Data docs

### DIFF
--- a/docs/source/api/models.rst
+++ b/docs/source/api/models.rst
@@ -9,4 +9,7 @@ All domain models are frozen dataclasses with ``slots=True``.
    models/ticketing
    models/help_center
    models/custom_data
+   models/voice
+   models/conversations
+   models/wfm
    models/shared_objects

--- a/docs/source/api/models/conversations.rst
+++ b/docs/source/api/models/conversations.rst
@@ -1,0 +1,19 @@
+Conversations Models
+====================
+
+.. toctree::
+   :maxdepth: 1
+
+   conversations/app
+   conversations/app_key
+   conversations/attachment
+   conversations/client
+   conversations/conversation
+   conversations/device
+   conversations/integration
+   conversations/integration_api_key
+   conversations/message
+   conversations/participant
+   conversations/switchboard
+   conversations/user
+   conversations/webhook

--- a/docs/source/api/models/conversations/app.rst
+++ b/docs/source/api/models/conversations/app.rst
@@ -1,0 +1,7 @@
+App
+===
+
+.. automodule:: libzapi.domain.models.conversations.app
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/conversations/app_key.rst
+++ b/docs/source/api/models/conversations/app_key.rst
@@ -1,0 +1,7 @@
+AppKey
+======
+
+.. automodule:: libzapi.domain.models.conversations.app_key
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/conversations/attachment.rst
+++ b/docs/source/api/models/conversations/attachment.rst
@@ -1,0 +1,7 @@
+Attachment
+==========
+
+.. automodule:: libzapi.domain.models.conversations.attachment
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/conversations/client.rst
+++ b/docs/source/api/models/conversations/client.rst
@@ -1,0 +1,7 @@
+Client
+======
+
+.. automodule:: libzapi.domain.models.conversations.client
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/conversations/conversation.rst
+++ b/docs/source/api/models/conversations/conversation.rst
@@ -1,0 +1,7 @@
+Conversation
+============
+
+.. automodule:: libzapi.domain.models.conversations.conversation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/conversations/device.rst
+++ b/docs/source/api/models/conversations/device.rst
@@ -1,0 +1,7 @@
+Device
+======
+
+.. automodule:: libzapi.domain.models.conversations.device
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/conversations/integration.rst
+++ b/docs/source/api/models/conversations/integration.rst
@@ -1,0 +1,7 @@
+Integration
+===========
+
+.. automodule:: libzapi.domain.models.conversations.integration
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/conversations/integration_api_key.rst
+++ b/docs/source/api/models/conversations/integration_api_key.rst
@@ -1,0 +1,7 @@
+IntegrationApiKey
+=================
+
+.. automodule:: libzapi.domain.models.conversations.integration_api_key
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/conversations/message.rst
+++ b/docs/source/api/models/conversations/message.rst
@@ -1,0 +1,7 @@
+Message
+=======
+
+.. automodule:: libzapi.domain.models.conversations.message
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/conversations/participant.rst
+++ b/docs/source/api/models/conversations/participant.rst
@@ -1,0 +1,7 @@
+Participant
+===========
+
+.. automodule:: libzapi.domain.models.conversations.participant
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/conversations/switchboard.rst
+++ b/docs/source/api/models/conversations/switchboard.rst
@@ -1,0 +1,7 @@
+Switchboard
+===========
+
+.. automodule:: libzapi.domain.models.conversations.switchboard
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/conversations/user.rst
+++ b/docs/source/api/models/conversations/user.rst
@@ -1,0 +1,7 @@
+User
+====
+
+.. automodule:: libzapi.domain.models.conversations.user
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/conversations/webhook.rst
+++ b/docs/source/api/models/conversations/webhook.rst
@@ -1,0 +1,7 @@
+Webhook
+=======
+
+.. automodule:: libzapi.domain.models.conversations.webhook
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/custom_data.rst
+++ b/docs/source/api/models/custom_data.rst
@@ -7,3 +7,8 @@ Custom Data Models
    custom_data/custom_object
    custom_data/custom_object_field
    custom_data/custom_object_record
+   custom_data/access_rule
+   custom_data/object_trigger
+   custom_data/permission_policy
+   custom_data/record_attachment
+   custom_data/record_event

--- a/docs/source/api/models/custom_data/access_rule.rst
+++ b/docs/source/api/models/custom_data/access_rule.rst
@@ -1,0 +1,7 @@
+AccessRule
+==========
+
+.. automodule:: libzapi.domain.models.custom_data.access_rule
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/custom_data/object_trigger.rst
+++ b/docs/source/api/models/custom_data/object_trigger.rst
@@ -1,0 +1,7 @@
+ObjectTrigger
+=============
+
+.. automodule:: libzapi.domain.models.custom_data.object_trigger
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/custom_data/permission_policy.rst
+++ b/docs/source/api/models/custom_data/permission_policy.rst
@@ -1,0 +1,7 @@
+PermissionPolicy
+================
+
+.. automodule:: libzapi.domain.models.custom_data.permission_policy
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/custom_data/record_attachment.rst
+++ b/docs/source/api/models/custom_data/record_attachment.rst
@@ -1,0 +1,7 @@
+RecordAttachment
+================
+
+.. automodule:: libzapi.domain.models.custom_data.record_attachment
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/custom_data/record_event.rst
+++ b/docs/source/api/models/custom_data/record_event.rst
@@ -1,0 +1,7 @@
+RecordEvent
+===========
+
+.. automodule:: libzapi.domain.models.custom_data.record_event
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/voice.rst
+++ b/docs/source/api/models/voice.rst
@@ -1,0 +1,15 @@
+Voice Models
+============
+
+.. toctree::
+   :maxdepth: 1
+
+   voice/address
+   voice/availability
+   voice/call
+   voice/digital_line
+   voice/greeting
+   voice/ivr
+   voice/phone_number
+   voice/stats
+   voice/voice_settings

--- a/docs/source/api/models/voice/address.rst
+++ b/docs/source/api/models/voice/address.rst
@@ -1,0 +1,7 @@
+Address
+=======
+
+.. automodule:: libzapi.domain.models.voice.address
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/voice/availability.rst
+++ b/docs/source/api/models/voice/availability.rst
@@ -1,0 +1,7 @@
+Availability
+============
+
+.. automodule:: libzapi.domain.models.voice.availability
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/voice/call.rst
+++ b/docs/source/api/models/voice/call.rst
@@ -1,0 +1,7 @@
+Call
+====
+
+.. automodule:: libzapi.domain.models.voice.call
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/voice/digital_line.rst
+++ b/docs/source/api/models/voice/digital_line.rst
@@ -1,0 +1,7 @@
+DigitalLine
+===========
+
+.. automodule:: libzapi.domain.models.voice.digital_line
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/voice/greeting.rst
+++ b/docs/source/api/models/voice/greeting.rst
@@ -1,0 +1,7 @@
+Greeting
+========
+
+.. automodule:: libzapi.domain.models.voice.greeting
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/voice/ivr.rst
+++ b/docs/source/api/models/voice/ivr.rst
@@ -1,0 +1,7 @@
+IVR
+===
+
+.. automodule:: libzapi.domain.models.voice.ivr
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/voice/phone_number.rst
+++ b/docs/source/api/models/voice/phone_number.rst
@@ -1,0 +1,7 @@
+PhoneNumber
+===========
+
+.. automodule:: libzapi.domain.models.voice.phone_number
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/voice/stats.rst
+++ b/docs/source/api/models/voice/stats.rst
@@ -1,0 +1,7 @@
+Stats
+=====
+
+.. automodule:: libzapi.domain.models.voice.stats
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/voice/voice_settings.rst
+++ b/docs/source/api/models/voice/voice_settings.rst
@@ -1,0 +1,7 @@
+VoiceSettings
+=============
+
+.. automodule:: libzapi.domain.models.voice.voice_settings
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/wfm.rst
+++ b/docs/source/api/models/wfm.rst
@@ -1,0 +1,11 @@
+Workforce Management Models
+===========================
+
+.. toctree::
+   :maxdepth: 1
+
+   wfm/activity
+   wfm/report
+   wfm/shift
+   wfm/team
+   wfm/time_off

--- a/docs/source/api/models/wfm/activity.rst
+++ b/docs/source/api/models/wfm/activity.rst
@@ -1,0 +1,7 @@
+Activity
+========
+
+.. automodule:: libzapi.domain.models.wfm.activity
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/wfm/report.rst
+++ b/docs/source/api/models/wfm/report.rst
@@ -1,0 +1,7 @@
+Report
+======
+
+.. automodule:: libzapi.domain.models.wfm.report
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/wfm/shift.rst
+++ b/docs/source/api/models/wfm/shift.rst
@@ -1,0 +1,7 @@
+Shift
+=====
+
+.. automodule:: libzapi.domain.models.wfm.shift
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/wfm/team.rst
+++ b/docs/source/api/models/wfm/team.rst
@@ -1,0 +1,7 @@
+Team
+====
+
+.. automodule:: libzapi.domain.models.wfm.team
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/models/wfm/time_off.rst
+++ b/docs/source/api/models/wfm/time_off.rst
@@ -1,0 +1,7 @@
+TimeOff
+=======
+
+.. automodule:: libzapi.domain.models.wfm.time_off
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/services.rst
+++ b/docs/source/api/services.rst
@@ -1,7 +1,7 @@
 Services
 ========
 
-The SDK exposes three top-level entry points, each grouping related services.
+The SDK exposes several top-level entry points, each grouping related services.
 
 .. toctree::
    :maxdepth: 1
@@ -9,3 +9,6 @@ The SDK exposes three top-level entry points, each grouping related services.
    services/ticketing
    services/help_center
    services/custom_data
+   services/voice
+   services/conversations
+   services/wfm

--- a/docs/source/api/services/conversations.rst
+++ b/docs/source/api/services/conversations.rst
@@ -1,0 +1,23 @@
+Conversations
+=============
+
+.. toctree::
+   :maxdepth: 1
+
+   conversations/conversations
+   conversations/activities_service
+   conversations/app_keys_service
+   conversations/apps_service
+   conversations/attachments_service
+   conversations/clients_service
+   conversations/conversations_service
+   conversations/devices_service
+   conversations/integration_api_keys_service
+   conversations/integrations_service
+   conversations/messages_service
+   conversations/participants_service
+   conversations/switchboard_actions_service
+   conversations/switchboard_integrations_service
+   conversations/switchboards_service
+   conversations/users_service
+   conversations/webhooks_service

--- a/docs/source/api/services/conversations/activities_service.rst
+++ b/docs/source/api/services/conversations/activities_service.rst
@@ -1,0 +1,6 @@
+ActivitiesService
+=================
+
+.. autoclass:: libzapi.application.services.conversations.activities_service.ActivitiesService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/app_keys_service.rst
+++ b/docs/source/api/services/conversations/app_keys_service.rst
@@ -1,0 +1,6 @@
+AppKeysService
+==============
+
+.. autoclass:: libzapi.application.services.conversations.app_keys_service.AppKeysService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/apps_service.rst
+++ b/docs/source/api/services/conversations/apps_service.rst
@@ -1,0 +1,6 @@
+AppsService
+===========
+
+.. autoclass:: libzapi.application.services.conversations.apps_service.AppsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/attachments_service.rst
+++ b/docs/source/api/services/conversations/attachments_service.rst
@@ -1,0 +1,6 @@
+AttachmentsService
+==================
+
+.. autoclass:: libzapi.application.services.conversations.attachments_service.AttachmentsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/clients_service.rst
+++ b/docs/source/api/services/conversations/clients_service.rst
@@ -1,0 +1,6 @@
+ClientsService
+==============
+
+.. autoclass:: libzapi.application.services.conversations.clients_service.ClientsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/conversations.rst
+++ b/docs/source/api/services/conversations/conversations.rst
@@ -1,0 +1,6 @@
+Conversations
+=============
+
+.. autoclass:: libzapi.application.services.conversations.Conversations
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/conversations_service.rst
+++ b/docs/source/api/services/conversations/conversations_service.rst
@@ -1,0 +1,6 @@
+ConversationsService
+====================
+
+.. autoclass:: libzapi.application.services.conversations.conversations_service.ConversationsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/devices_service.rst
+++ b/docs/source/api/services/conversations/devices_service.rst
@@ -1,0 +1,6 @@
+DevicesService
+==============
+
+.. autoclass:: libzapi.application.services.conversations.devices_service.DevicesService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/integration_api_keys_service.rst
+++ b/docs/source/api/services/conversations/integration_api_keys_service.rst
@@ -1,0 +1,6 @@
+IntegrationApiKeysService
+=========================
+
+.. autoclass:: libzapi.application.services.conversations.integration_api_keys_service.IntegrationApiKeysService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/integrations_service.rst
+++ b/docs/source/api/services/conversations/integrations_service.rst
@@ -1,0 +1,6 @@
+IntegrationsService
+===================
+
+.. autoclass:: libzapi.application.services.conversations.integrations_service.IntegrationsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/messages_service.rst
+++ b/docs/source/api/services/conversations/messages_service.rst
@@ -1,0 +1,6 @@
+MessagesService
+===============
+
+.. autoclass:: libzapi.application.services.conversations.messages_service.MessagesService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/participants_service.rst
+++ b/docs/source/api/services/conversations/participants_service.rst
@@ -1,0 +1,6 @@
+ParticipantsService
+===================
+
+.. autoclass:: libzapi.application.services.conversations.participants_service.ParticipantsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/switchboard_actions_service.rst
+++ b/docs/source/api/services/conversations/switchboard_actions_service.rst
@@ -1,0 +1,6 @@
+SwitchboardActionsService
+=========================
+
+.. autoclass:: libzapi.application.services.conversations.switchboard_actions_service.SwitchboardActionsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/switchboard_integrations_service.rst
+++ b/docs/source/api/services/conversations/switchboard_integrations_service.rst
@@ -1,0 +1,6 @@
+SwitchboardIntegrationsService
+==============================
+
+.. autoclass:: libzapi.application.services.conversations.switchboard_integrations_service.SwitchboardIntegrationsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/switchboards_service.rst
+++ b/docs/source/api/services/conversations/switchboards_service.rst
@@ -1,0 +1,6 @@
+SwitchboardsService
+===================
+
+.. autoclass:: libzapi.application.services.conversations.switchboards_service.SwitchboardsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/users_service.rst
+++ b/docs/source/api/services/conversations/users_service.rst
@@ -1,0 +1,6 @@
+UsersService
+============
+
+.. autoclass:: libzapi.application.services.conversations.users_service.UsersService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/conversations/webhooks_service.rst
+++ b/docs/source/api/services/conversations/webhooks_service.rst
@@ -1,0 +1,6 @@
+WebhooksService
+===============
+
+.. autoclass:: libzapi.application.services.conversations.webhooks_service.WebhooksService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/custom_data.rst
+++ b/docs/source/api/services/custom_data.rst
@@ -8,3 +8,8 @@ Custom Data
    custom_data/custom_objects_service
    custom_data/custom_object_fields_service
    custom_data/custom_object_records_service
+   custom_data/access_rules_service
+   custom_data/object_triggers_service
+   custom_data/permission_policies_service
+   custom_data/record_attachments_service
+   custom_data/record_events_service

--- a/docs/source/api/services/custom_data/access_rules_service.rst
+++ b/docs/source/api/services/custom_data/access_rules_service.rst
@@ -1,0 +1,6 @@
+AccessRulesService
+==================
+
+.. autoclass:: libzapi.application.services.custom_data.access_rules_service.AccessRulesService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/custom_data/object_triggers_service.rst
+++ b/docs/source/api/services/custom_data/object_triggers_service.rst
@@ -1,0 +1,6 @@
+ObjectTriggersService
+=====================
+
+.. autoclass:: libzapi.application.services.custom_data.object_triggers_service.ObjectTriggersService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/custom_data/permission_policies_service.rst
+++ b/docs/source/api/services/custom_data/permission_policies_service.rst
@@ -1,0 +1,6 @@
+PermissionPoliciesService
+=========================
+
+.. autoclass:: libzapi.application.services.custom_data.permission_policies_service.PermissionPoliciesService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/custom_data/record_attachments_service.rst
+++ b/docs/source/api/services/custom_data/record_attachments_service.rst
@@ -1,0 +1,6 @@
+RecordAttachmentsService
+========================
+
+.. autoclass:: libzapi.application.services.custom_data.record_attachments_service.RecordAttachmentsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/custom_data/record_events_service.rst
+++ b/docs/source/api/services/custom_data/record_events_service.rst
@@ -1,0 +1,6 @@
+RecordEventsService
+===================
+
+.. autoclass:: libzapi.application.services.custom_data.record_events_service.RecordEventsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/voice.rst
+++ b/docs/source/api/services/voice.rst
@@ -1,0 +1,21 @@
+Voice
+=====
+
+.. toctree::
+   :maxdepth: 1
+
+   voice/voice
+   voice/addresses_service
+   voice/availabilities_service
+   voice/callback_requests_service
+   voice/digital_lines_service
+   voice/greetings_service
+   voice/incremental_exports_service
+   voice/ivr_menus_service
+   voice/ivr_routes_service
+   voice/ivrs_service
+   voice/lines_service
+   voice/phone_numbers_service
+   voice/recordings_service
+   voice/stats_service
+   voice/voice_settings_service

--- a/docs/source/api/services/voice/addresses_service.rst
+++ b/docs/source/api/services/voice/addresses_service.rst
@@ -1,0 +1,6 @@
+AddressesService
+================
+
+.. autoclass:: libzapi.application.services.voice.addresses_service.AddressesService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/voice/availabilities_service.rst
+++ b/docs/source/api/services/voice/availabilities_service.rst
@@ -1,0 +1,6 @@
+AvailabilitiesService
+=====================
+
+.. autoclass:: libzapi.application.services.voice.availabilities_service.AvailabilitiesService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/voice/callback_requests_service.rst
+++ b/docs/source/api/services/voice/callback_requests_service.rst
@@ -1,0 +1,6 @@
+CallbackRequestsService
+=======================
+
+.. autoclass:: libzapi.application.services.voice.callback_requests_service.CallbackRequestsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/voice/digital_lines_service.rst
+++ b/docs/source/api/services/voice/digital_lines_service.rst
@@ -1,0 +1,6 @@
+DigitalLinesService
+===================
+
+.. autoclass:: libzapi.application.services.voice.digital_lines_service.DigitalLinesService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/voice/greetings_service.rst
+++ b/docs/source/api/services/voice/greetings_service.rst
@@ -1,0 +1,6 @@
+GreetingsService
+================
+
+.. autoclass:: libzapi.application.services.voice.greetings_service.GreetingsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/voice/incremental_exports_service.rst
+++ b/docs/source/api/services/voice/incremental_exports_service.rst
@@ -1,0 +1,6 @@
+IncrementalExportsService
+=========================
+
+.. autoclass:: libzapi.application.services.voice.incremental_exports_service.IncrementalExportsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/voice/ivr_menus_service.rst
+++ b/docs/source/api/services/voice/ivr_menus_service.rst
@@ -1,0 +1,6 @@
+IvrMenusService
+===============
+
+.. autoclass:: libzapi.application.services.voice.ivr_menus_service.IvrMenusService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/voice/ivr_routes_service.rst
+++ b/docs/source/api/services/voice/ivr_routes_service.rst
@@ -1,0 +1,6 @@
+IvrRoutesService
+================
+
+.. autoclass:: libzapi.application.services.voice.ivr_routes_service.IvrRoutesService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/voice/ivrs_service.rst
+++ b/docs/source/api/services/voice/ivrs_service.rst
@@ -1,0 +1,6 @@
+IvrsService
+===========
+
+.. autoclass:: libzapi.application.services.voice.ivrs_service.IvrsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/voice/lines_service.rst
+++ b/docs/source/api/services/voice/lines_service.rst
@@ -1,0 +1,6 @@
+LinesService
+============
+
+.. autoclass:: libzapi.application.services.voice.lines_service.LinesService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/voice/phone_numbers_service.rst
+++ b/docs/source/api/services/voice/phone_numbers_service.rst
@@ -1,0 +1,6 @@
+PhoneNumbersService
+===================
+
+.. autoclass:: libzapi.application.services.voice.phone_numbers_service.PhoneNumbersService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/voice/recordings_service.rst
+++ b/docs/source/api/services/voice/recordings_service.rst
@@ -1,0 +1,6 @@
+RecordingsService
+=================
+
+.. autoclass:: libzapi.application.services.voice.recordings_service.RecordingsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/voice/stats_service.rst
+++ b/docs/source/api/services/voice/stats_service.rst
@@ -1,0 +1,6 @@
+StatsService
+============
+
+.. autoclass:: libzapi.application.services.voice.stats_service.StatsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/voice/voice.rst
+++ b/docs/source/api/services/voice/voice.rst
@@ -1,0 +1,6 @@
+Voice
+=====
+
+.. autoclass:: libzapi.application.services.voice.Voice
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/voice/voice_settings_service.rst
+++ b/docs/source/api/services/voice/voice_settings_service.rst
@@ -1,0 +1,6 @@
+VoiceSettingsService
+====================
+
+.. autoclass:: libzapi.application.services.voice.voice_settings_service.VoiceSettingsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/wfm.rst
+++ b/docs/source/api/services/wfm.rst
@@ -1,0 +1,12 @@
+Workforce Management
+====================
+
+.. toctree::
+   :maxdepth: 1
+
+   wfm/wfm
+   wfm/activities_service
+   wfm/reports_service
+   wfm/shifts_service
+   wfm/teams_service
+   wfm/time_off_service

--- a/docs/source/api/services/wfm/activities_service.rst
+++ b/docs/source/api/services/wfm/activities_service.rst
@@ -1,0 +1,6 @@
+ActivitiesService
+=================
+
+.. autoclass:: libzapi.application.services.wfm.activities_service.ActivitiesService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/wfm/reports_service.rst
+++ b/docs/source/api/services/wfm/reports_service.rst
@@ -1,0 +1,6 @@
+ReportsService
+==============
+
+.. autoclass:: libzapi.application.services.wfm.reports_service.ReportsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/wfm/shifts_service.rst
+++ b/docs/source/api/services/wfm/shifts_service.rst
@@ -1,0 +1,6 @@
+ShiftsService
+=============
+
+.. autoclass:: libzapi.application.services.wfm.shifts_service.ShiftsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/wfm/teams_service.rst
+++ b/docs/source/api/services/wfm/teams_service.rst
@@ -1,0 +1,6 @@
+TeamsService
+============
+
+.. autoclass:: libzapi.application.services.wfm.teams_service.TeamsService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/wfm/time_off_service.rst
+++ b/docs/source/api/services/wfm/time_off_service.rst
@@ -1,0 +1,6 @@
+TimeOffService
+==============
+
+.. autoclass:: libzapi.application.services.wfm.time_off_service.TimeOffService
+   :members:
+   :undoc-members:

--- a/docs/source/api/services/wfm/wfm.rst
+++ b/docs/source/api/services/wfm/wfm.rst
@@ -1,0 +1,6 @@
+WorkforceManagement
+===================
+
+.. autoclass:: libzapi.application.services.wfm.WorkforceManagement
+   :members:
+   :undoc-members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 project = "libzapi"
 copyright = "2025, Leandro Meili"
 author = "Leandro Meili"
-release = "0.6.4"
+release = "0.9.0"
 
 # -- General configuration ---------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add full Sphinx autodoc documentation for **Voice** (14 services, 9 models)
- Add full Sphinx autodoc documentation for **Conversations** (17 services, 13 models)
- Add full Sphinx autodoc documentation for **Workforce Management** (5 services, 5 models)
- Complete **Custom Data** documentation with missing services (5) and models (5)
- Update `conf.py` version to 0.9.0
- Update top-level service and model index files

## Test plan
- [x] `sphinx-build` succeeds with no errors (1 pre-existing warning about `_static`)
- [ ] Verify docs deploy after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)