### PR TITLE
Retry HTTP requests on dead connections

### DIFF
--- a/libzapi/infrastructure/http/client.py
+++ b/libzapi/infrastructure/http/client.py
@@ -1,4 +1,5 @@
 import time
+from http.client import RemoteDisconnected
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -40,9 +41,17 @@ class HttpClient:
             self.session.close()
             self.session = self._new_session()
 
-    def get(self, path: str, params: dict | None = None) -> dict:
+    def _request(self, method: str, path: str, **kwargs) -> requests.Response:
         self._refresh_if_stale()
-        resp = self.session.get(f"{self.base_url}{path}", params=params, timeout=self.timeout)
+        try:
+            return self.session.request(method, f"{self.base_url}{path}", **kwargs)
+        except (requests.ConnectionError, RemoteDisconnected):
+            self.session.close()
+            self.session = self._new_session()
+            return self.session.request(method, f"{self.base_url}{path}", **kwargs)
+
+    def get(self, path: str, params: dict | None = None) -> dict:
+        resp = self._request("GET", path, params=params, timeout=self.timeout)
         self._raise(resp)
         return resp.json()
 
@@ -62,27 +71,24 @@ class HttpClient:
         return resp.json()
 
     def post(self, path: str, json: dict) -> dict:
-        self._refresh_if_stale()
-        resp = self.session.post(f"{self.base_url}{path}", json=json, timeout=self.timeout)
+        resp = self._request("POST", path, json=json, timeout=self.timeout)
         self._raise(resp)
         return resp.json()
 
     def put(self, path: str, json: dict) -> dict:
-        self._refresh_if_stale()
-        resp = self.session.put(f"{self.base_url}{path}", json=json, timeout=self.timeout)
+        resp = self._request("PUT", path, json=json, timeout=self.timeout)
         self._raise(resp)
         return resp.json()
 
     def patch(self, path: str, json: dict) -> dict:
-        self._refresh_if_stale()
-        resp = self.session.patch(f"{self.base_url}{path}", json=json, timeout=self.timeout)
+        resp = self._request("PATCH", path, json=json, timeout=self.timeout)
         self._raise(resp)
         return resp.json()
 
     def post_multipart(self, path: str, files: dict, data: dict | None = None) -> dict:
-        self._refresh_if_stale()
-        resp = self.session.post(
-            f"{self.base_url}{path}",
+        resp = self._request(
+            "POST",
+            path,
             files=files,
             data=data,
             headers={"Content-Type": None},
@@ -92,8 +98,7 @@ class HttpClient:
         return resp.json()
 
     def delete(self, path: str) -> None:
-        self._refresh_if_stale()
-        resp = self.session.delete(f"{self.base_url}{path}", timeout=self.timeout)
+        resp = self._request("DELETE", path, timeout=self.timeout)
         self._raise(resp)
 
     @staticmethod

--- a/libzapi/infrastructure/http/client.py
+++ b/libzapi/infrastructure/http/client.py
@@ -50,6 +50,26 @@ class HttpClient:
             self.session = self._new_session()
             return self.session.request(method, f"{self.base_url}{path}", **kwargs)
 
+    def _prepare_and_send(self, method: str, url: str, **kwargs) -> requests.Response:
+        req = requests.Request(method, url, headers=self.session.headers)
+        prepared = req.prepare()
+        prepared.url = url  # override to prevent percent-encoding of brackets
+        return self.session.send(prepared, **kwargs)
+
+    def _request_raw(self, method: str, url: str, **kwargs) -> requests.Response:
+        """Send a request with a pre-built URL, bypassing percent-encoding.
+
+        Uses a manually prepared request so that literal characters like
+        brackets in ``page[size]`` are preserved.
+        """
+        self._refresh_if_stale()
+        try:
+            return self._prepare_and_send(method, url, **kwargs)
+        except (requests.ConnectionError, RemoteDisconnected):
+            self.session.close()
+            self.session = self._new_session()
+            return self._prepare_and_send(method, url, **kwargs)
+
     def get(self, path: str, params: dict | None = None) -> dict:
         resp = self._request("GET", path, params=params, timeout=self.timeout)
         self._raise(resp)
@@ -62,11 +82,7 @@ class HttpClient:
         in query parameters like ``page[size]`` which ``requests``
         would otherwise percent-encode.
         """
-        self._refresh_if_stale()
-        req = requests.Request("GET", url, headers=self.session.headers)
-        prepared = req.prepare()
-        prepared.url = url  # override to prevent percent-encoding of brackets
-        resp = self.session.send(prepared, timeout=self.timeout)
+        resp = self._request_raw("GET", url, timeout=self.timeout)
         self._raise(resp)
         return resp.json()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "libzapi"
-version = "0.9.0"
+version = "0.9.1"
 authors = [
     { name = "Leandro Meili", email = "leandro.meili@bcrcx.com"},
     ]

--- a/tests/unit/infrastructure/http/test_client.py
+++ b/tests/unit/infrastructure/http/test_client.py
@@ -271,3 +271,93 @@ def test_request_retry_failure_propagates(mocker):
 
     with pytest.raises(requests.ConnectionError, match="second"):
         client.get("/api/v2/tickets/1.json")
+
+
+# ---------------------------------------------------------------------------
+# GET raw
+# ---------------------------------------------------------------------------
+
+
+def test_get_raw_returns_json(mocker):
+    client = HttpClient("https://example.zendesk.com", headers={})
+    resp = _make_response(200, json_data={"items": [1, 2, 3]})
+    mocker.patch.object(client.session, "send", return_value=resp)
+
+    url = "https://example.zendesk.com/api/v2/items?page[size]=10&page[after]=abc"
+    result = client.get_raw(url)
+
+    assert result == {"items": [1, 2, 3]}
+    prepared = client.session.send.call_args[0][0]
+    assert prepared.url == url
+
+
+def test_get_raw_raises_on_error(mocker):
+    client = HttpClient("https://example.zendesk.com", headers={})
+    resp = _make_response(404, text="Not Found")
+    mocker.patch.object(client.session, "send", return_value=resp)
+
+    with pytest.raises(NotFound, match="Not Found"):
+        client.get_raw("https://example.zendesk.com/api/v2/items?page[size]=10")
+
+
+def test_get_raw_retries_on_connection_error(mocker):
+    client = HttpClient("https://example.zendesk.com", headers={})
+    resp = _make_response(200, json_data={"ok": True})
+
+    original_session = client.session
+    mocker.patch.object(original_session, "send", side_effect=requests.ConnectionError("Connection aborted"))
+    mocker.patch.object(original_session, "close")
+
+    new_session = Mock(spec=requests.Session)
+    new_session.send.return_value = resp
+    new_session.headers = original_session.headers
+    mocker.patch.object(client, "_new_session", return_value=new_session)
+
+    url = "https://example.zendesk.com/api/v2/items?page[size]=10"
+    result = client.get_raw(url)
+
+    original_session.close.assert_called_once()
+    assert client.session is new_session
+    prepared = new_session.send.call_args[0][0]
+    assert prepared.url == url
+    assert result == {"ok": True}
+
+
+def test_get_raw_retries_on_remote_disconnected(mocker):
+    client = HttpClient("https://example.zendesk.com", headers={})
+    resp = _make_response(200, json_data={"ok": True})
+
+    original_session = client.session
+    mocker.patch.object(
+        original_session,
+        "send",
+        side_effect=RemoteDisconnected("Remote end closed connection without response"),
+    )
+    mocker.patch.object(original_session, "close")
+
+    new_session = Mock(spec=requests.Session)
+    new_session.send.return_value = resp
+    new_session.headers = original_session.headers
+    mocker.patch.object(client, "_new_session", return_value=new_session)
+
+    result = client.get_raw("https://example.zendesk.com/api/v2/items?page[size]=10")
+
+    original_session.close.assert_called_once()
+    assert client.session is new_session
+    assert result == {"ok": True}
+
+
+def test_get_raw_retry_failure_propagates(mocker):
+    client = HttpClient("https://example.zendesk.com", headers={})
+
+    original_session = client.session
+    mocker.patch.object(original_session, "send", side_effect=requests.ConnectionError("first"))
+    mocker.patch.object(original_session, "close")
+
+    new_session = Mock(spec=requests.Session)
+    new_session.send.side_effect = requests.ConnectionError("second")
+    new_session.headers = original_session.headers
+    mocker.patch.object(client, "_new_session", return_value=new_session)
+
+    with pytest.raises(requests.ConnectionError, match="second"):
+        client.get_raw("https://example.zendesk.com/api/v2/items?page[size]=10")

--- a/tests/unit/infrastructure/http/test_client.py
+++ b/tests/unit/infrastructure/http/test_client.py
@@ -1,3 +1,4 @@
+from http.client import RemoteDisconnected
 from unittest.mock import Mock
 
 import pytest
@@ -68,12 +69,12 @@ def test_raise_200_does_nothing():
 def test_get_returns_json(mocker):
     client = HttpClient("https://example.zendesk.com/", headers={"Authorization": "Bearer tok"})
     resp = _make_response(200, json_data={"ticket": {"id": 1}})
-    mocker.patch.object(client.session, "get", return_value=resp)
+    mocker.patch.object(client.session, "request", return_value=resp)
 
     result = client.get("/api/v2/tickets/1.json")
 
-    client.session.get.assert_called_once_with(
-        "https://example.zendesk.com/api/v2/tickets/1.json", params=None, timeout=30.0
+    client.session.request.assert_called_once_with(
+        "GET", "https://example.zendesk.com/api/v2/tickets/1.json", params=None, timeout=30.0
     )
     assert result == {"ticket": {"id": 1}}
 
@@ -81,7 +82,7 @@ def test_get_returns_json(mocker):
 def test_get_raises_on_error(mocker):
     client = HttpClient("https://example.zendesk.com", headers={})
     resp = _make_response(404, text="Not Found")
-    mocker.patch.object(client.session, "get", return_value=resp)
+    mocker.patch.object(client.session, "request", return_value=resp)
 
     with pytest.raises(NotFound, match="Not Found"):
         client.get("/api/v2/tickets/999.json")
@@ -96,12 +97,12 @@ def test_post_sends_json_and_returns_response(mocker):
     client = HttpClient("https://example.zendesk.com", headers={})
     payload = {"ticket": {"subject": "Help"}}
     resp = _make_response(201, json_data={"ticket": {"id": 42, "subject": "Help"}})
-    mocker.patch.object(client.session, "post", return_value=resp)
+    mocker.patch.object(client.session, "request", return_value=resp)
 
     result = client.post("/api/v2/tickets.json", json=payload)
 
-    client.session.post.assert_called_once_with(
-        "https://example.zendesk.com/api/v2/tickets.json", json=payload, timeout=30.0
+    client.session.request.assert_called_once_with(
+        "POST", "https://example.zendesk.com/api/v2/tickets.json", json=payload, timeout=30.0
     )
     assert result == {"ticket": {"id": 42, "subject": "Help"}}
 
@@ -109,7 +110,7 @@ def test_post_sends_json_and_returns_response(mocker):
 def test_post_raises_on_error(mocker):
     client = HttpClient("https://example.zendesk.com", headers={})
     resp = _make_response(401, text="Invalid credentials")
-    mocker.patch.object(client.session, "post", return_value=resp)
+    mocker.patch.object(client.session, "request", return_value=resp)
 
     with pytest.raises(Unauthorized, match="Invalid credentials"):
         client.post("/api/v2/tickets.json", json={})
@@ -124,12 +125,12 @@ def test_put_sends_json_and_returns_response(mocker):
     client = HttpClient("https://example.zendesk.com", headers={})
     payload = {"ticket": {"status": "solved"}}
     resp = _make_response(200, json_data={"ticket": {"id": 1, "status": "solved"}})
-    mocker.patch.object(client.session, "put", return_value=resp)
+    mocker.patch.object(client.session, "request", return_value=resp)
 
     result = client.put("/api/v2/tickets/1.json", json=payload)
 
-    client.session.put.assert_called_once_with(
-        "https://example.zendesk.com/api/v2/tickets/1.json", json=payload, timeout=30.0
+    client.session.request.assert_called_once_with(
+        "PUT", "https://example.zendesk.com/api/v2/tickets/1.json", json=payload, timeout=30.0
     )
     assert result == {"ticket": {"id": 1, "status": "solved"}}
 
@@ -142,18 +143,20 @@ def test_put_sends_json_and_returns_response(mocker):
 def test_delete_returns_none(mocker):
     client = HttpClient("https://example.zendesk.com", headers={})
     resp = _make_response(204)
-    mocker.patch.object(client.session, "delete", return_value=resp)
+    mocker.patch.object(client.session, "request", return_value=resp)
 
     result = client.delete("/api/v2/tickets/1.json")
 
-    client.session.delete.assert_called_once_with("https://example.zendesk.com/api/v2/tickets/1.json", timeout=30.0)
+    client.session.request.assert_called_once_with(
+        "DELETE", "https://example.zendesk.com/api/v2/tickets/1.json", timeout=30.0
+    )
     assert result is None
 
 
 def test_delete_does_not_call_json(mocker):
     client = HttpClient("https://example.zendesk.com", headers={})
     resp = _make_response(204)
-    mocker.patch.object(client.session, "delete", return_value=resp)
+    mocker.patch.object(client.session, "request", return_value=resp)
 
     client.delete("/api/v2/tickets/1.json")
 
@@ -195,3 +198,76 @@ def test_constructor_mounts_retry_adapter():
     assert adapter.max_retries.backoff_factor == 0.3
     assert 429 in adapter.max_retries.status_forcelist
     assert 500 in adapter.max_retries.status_forcelist
+
+
+# ---------------------------------------------------------------------------
+# _request: retry on connection errors
+# ---------------------------------------------------------------------------
+
+
+def test_request_retries_on_connection_error(mocker):
+    client = HttpClient("https://example.zendesk.com", headers={})
+    resp = _make_response(200, json_data={"ok": True})
+
+    original_session = client.session
+    mocker.patch.object(original_session, "request", side_effect=requests.ConnectionError("Connection aborted"))
+    mocker.patch.object(original_session, "close")
+
+    new_session = Mock(spec=requests.Session)
+    new_session.request.return_value = resp
+    mocker.patch.object(client, "_new_session", return_value=new_session)
+
+    result = client.get("/api/v2/tickets/1.json")
+
+    original_session.close.assert_called_once()
+    assert client.session is new_session
+    new_session.request.assert_called_once_with(
+        "GET", "https://example.zendesk.com/api/v2/tickets/1.json", params=None, timeout=30.0
+    )
+    assert result == {"ok": True}
+
+
+def test_request_retries_on_remote_disconnected(mocker):
+    client = HttpClient("https://example.zendesk.com", headers={})
+    resp = _make_response(200, json_data={"ok": True})
+
+    original_session = client.session
+    mocker.patch.object(
+        original_session,
+        "request",
+        side_effect=RemoteDisconnected("Remote end closed connection without response"),
+    )
+    mocker.patch.object(original_session, "close")
+
+    new_session = Mock(spec=requests.Session)
+    new_session.request.return_value = resp
+    mocker.patch.object(client, "_new_session", return_value=new_session)
+
+    result = client.get("/api/v2/tickets/1.json")
+
+    original_session.close.assert_called_once()
+    assert client.session is new_session
+    assert result == {"ok": True}
+
+
+def test_request_does_not_retry_on_other_errors(mocker):
+    client = HttpClient("https://example.zendesk.com", headers={})
+    mocker.patch.object(client.session, "request", side_effect=requests.Timeout("timed out"))
+
+    with pytest.raises(requests.Timeout, match="timed out"):
+        client.get("/api/v2/tickets/1.json")
+
+
+def test_request_retry_failure_propagates(mocker):
+    client = HttpClient("https://example.zendesk.com", headers={})
+
+    original_session = client.session
+    mocker.patch.object(original_session, "request", side_effect=requests.ConnectionError("first"))
+    mocker.patch.object(original_session, "close")
+
+    new_session = Mock(spec=requests.Session)
+    new_session.request.side_effect = requests.ConnectionError("second")
+    mocker.patch.object(client, "_new_session", return_value=new_session)
+
+    with pytest.raises(requests.ConnectionError, match="second"):
+        client.get("/api/v2/tickets/1.json")


### PR DESCRIPTION
# Retry Request em conexões mortas

## Prefácio
O fix anterior (commit 30f8968) introduziu um refresh proativo de sessão baseado em um threshold de 5 minutos (`CONNECTION_MAX_AGE`). Apesar de ajudar em alguns casos, não previne erros de `RemoteDisconnected` — o servidor ou um load balancer intermediário pode fechar a conexão TCP a qualquer momento antes da janela de 5 minutos expirar, deixando o próximo request em um socket morto.                                            

Este PR introduz um método centralizado `_request()` com uma estratégia de retry reativo por cima do refresh proativo existente, além de  preservar o suporte a `params` no `get()` e o método `get_raw()` para URLs pré-construídas.


# CHANGELOG
  - `15b053bfdb88`: Retry HTTP requests on dead connections instead of only refreshing                                                             
  > Introduz `_request()` como ponto único de dispatch para todos os métodos HTTP (`get`, `post`, `put`, `patch`, `delete`, `post_multipart`). Em caso de `ConnectionError` ou `RemoteDisconnected`, a sessão é fechada, uma nova é criada e o request é retentado exatamente uma vez. Se o retry também falhar, a exceção é propagada normalmente. Também preserva `get(params=)` e `get_raw()` para URLs com brackets literais (e.g. `page[size]`).                                                                                                                                   
                                                                                                                                                 
  - `c18d5f061449`: Delegate get_raw to _request_raw with connection retry                                                                         
  > Extrai `_prepare_and_send` e `_request_raw` para que `get_raw` se beneficie da mesma lógica de retry em conexões mortas que os demais métodos HTTP.                             
                                                                                                                                                 
  - `21dc0c40f861`: Add tests for get_raw and _request_raw connection retry                                                                        
  > Adiciona 5 novos testes cobrindo: happy path, error mapping, retry em `ConnectionError`, retry em `RemoteDisconnected` e propagação de falha no retry.                           
    
  - `a9492e784aab`: Bump version to 0.9.1  
# REQUISITOS PARA O PR
<!-- Tópico não obrigatório (use para demarcar algumas flags para o PR) -->
- [x] Ajuste as Flags referente ao PR (conforme os issues);
- [x] Escreva uma boa descrição para o PR. Se fizer algo de qualquer jeito, muito provavelmente vai e DEVE ser recusado;
- [x] Declare se o PR está com os testes atualizados;
- [x] Para aprovação, é necessário o CI passar (com algumas exceções);
- [x] Utilize as configs de pre-commit antes de subir o PR;
- [x] Confira se a sua branch está atualizada com a branch default de repositório;
- [x] Não há `*.log`, `print`, `código comentado` ou `dados sensíveis no diff` (Não deixe código comentado e verifique seus commits antes de dar `push`, é exatamento para isso que o git serve).

<!-- 
- Caso algum desses tópicos não sejam marcados, o PR ainda pode ser aprovado, eles apenas funcionam para uma filtragem de qualidade.
- Pode-se retirar essa lista de requisitos também para demonstrar que todos estão ok.
- No fim, sabemos que nem tudo pode ser alcançado, apenas seja objetivo caso algo não esteja nos padrões, e lembre-se LGTM!
-->
