### PR TITLE
feat(ticketing): add users CUD, merge, tags, related, deleted users

### DIFF
--- a/libzapi/application/commands/ticketing/user_cmds.py
+++ b/libzapi/application/commands/ticketing/user_cmds.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, TypeAlias
+
+
+@dataclass(frozen=True, slots=True)
+class CreateUserCmd:
+    name: str
+    email: str | None = None
+    role: str | None = None
+    phone: str | None = None
+    alias: str | None = None
+    external_id: str | None = None
+    organization_id: int | None = None
+    custom_role_id: int | None = None
+    default_group_id: int | None = None
+    details: str | None = None
+    notes: str | None = None
+    locale_id: int | None = None
+    time_zone: str | None = None
+    verified: bool | None = None
+    active: bool | None = None
+    moderator: bool | None = None
+    only_private_comments: bool | None = None
+    restricted_agent: bool | None = None
+    suspended: bool | None = None
+    ticket_restriction: str | None = None
+    tags: Iterable[str] | None = None
+    user_fields: dict | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateUserCmd:
+    name: str | None = None
+    email: str | None = None
+    role: str | None = None
+    phone: str | None = None
+    alias: str | None = None
+    external_id: str | None = None
+    organization_id: int | None = None
+    custom_role_id: int | None = None
+    default_group_id: int | None = None
+    details: str | None = None
+    notes: str | None = None
+    locale_id: int | None = None
+    time_zone: str | None = None
+    verified: bool | None = None
+    active: bool | None = None
+    moderator: bool | None = None
+    only_private_comments: bool | None = None
+    restricted_agent: bool | None = None
+    suspended: bool | None = None
+    ticket_restriction: str | None = None
+    tags: Iterable[str] | None = None
+    user_fields: dict | None = None
+
+
+UserCmd: TypeAlias = CreateUserCmd | UpdateUserCmd

--- a/libzapi/application/services/ticketing/users_service.py
+++ b/libzapi/application/services/ticketing/users_service.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 from typing import Iterable
 
-from libzapi.domain.models.ticketing.user import User
+from libzapi.application.commands.ticketing.user_cmds import CreateUserCmd, UpdateUserCmd
+from libzapi.domain.models.ticketing.user import ComplianceDeletionStatus, User, UserRelated
 from libzapi.domain.shared_objects.count_snapshot import CountSnapshot
+from libzapi.domain.shared_objects.job_status import JobStatus
 from libzapi.infrastructure.api_clients.ticketing.user_api_client import UserApiClient
 
 
@@ -31,3 +35,95 @@ class UsersService:
 
     def get_by_id(self, user_id: int) -> User:
         return self._client.get(user_id)
+
+    def me(self) -> User:
+        return self._client.me()
+
+    def show_many(self, user_ids: Iterable[int]) -> Iterable[User]:
+        return self._client.show_many(user_ids=user_ids)
+
+    def search(self, query: str | None = None, external_id: str | None = None) -> Iterable[User]:
+        return self._client.search(query=query, external_id=external_id)
+
+    def autocomplete(self, name: str) -> Iterable[User]:
+        return self._client.autocomplete(name=name)
+
+    def list_related(self, user_id: int) -> UserRelated:
+        return self._client.list_related(user_id=user_id)
+
+    def list_compliance_deletion_statuses(
+        self, user_id: int
+    ) -> Iterable[ComplianceDeletionStatus]:
+        return self._client.list_compliance_deletion_statuses(user_id=user_id)
+
+    def list_deleted(self) -> Iterable[User]:
+        return self._client.list_deleted()
+
+    def count_deleted(self) -> CountSnapshot:
+        return self._client.count_deleted()
+
+    def show_deleted(self, deleted_user_id: int) -> User:
+        return self._client.show_deleted(deleted_user_id=deleted_user_id)
+
+    def me_settings(self) -> dict:
+        return self._client.me_settings()
+
+    def update_me_settings(self, settings: dict) -> dict:
+        return self._client.update_me_settings(settings=settings)
+
+    def list_entitlements(self, user_id: int) -> list[dict]:
+        return self._client.list_entitlements(user_id=user_id)
+
+    def create(self, **fields) -> User:
+        return self._client.create(entity=CreateUserCmd(**fields))
+
+    def update(self, user_id: int, **fields) -> User:
+        return self._client.update(user_id=user_id, entity=UpdateUserCmd(**fields))
+
+    def delete(self, user_id: int) -> User:
+        return self._client.delete(user_id=user_id)
+
+    def create_many(self, users: Iterable[dict]) -> JobStatus:
+        return self._client.create_many(entities=[CreateUserCmd(**u) for u in users])
+
+    def create_or_update(self, **fields) -> User:
+        return self._client.create_or_update(entity=CreateUserCmd(**fields))
+
+    def create_or_update_many(self, users: Iterable[dict]) -> JobStatus:
+        return self._client.create_or_update_many(entities=[CreateUserCmd(**u) for u in users])
+
+    def update_many(self, user_ids: Iterable[int], **fields) -> JobStatus:
+        return self._client.update_many(user_ids=user_ids, entity=UpdateUserCmd(**fields))
+
+    def update_many_individually(
+        self, updates: Iterable[tuple[int, dict]]
+    ) -> JobStatus:
+        pairs = [(user_id, UpdateUserCmd(**fields)) for user_id, fields in updates]
+        return self._client.update_many_individually(updates=pairs)
+
+    def destroy_many(self, user_ids: Iterable[int]) -> JobStatus:
+        return self._client.destroy_many(user_ids=user_ids)
+
+    def merge(self, source_user_id: int, target_user_id: int) -> User:
+        return self._client.merge(source_user_id=source_user_id, target_user_id=target_user_id)
+
+    def permanently_delete(self, deleted_user_id: int) -> User:
+        return self._client.permanently_delete(deleted_user_id=deleted_user_id)
+
+    def request_create(self, **fields) -> dict:
+        return self._client.request_create(entity=CreateUserCmd(**fields))
+
+    def logout_many(self, user_ids: Iterable[int]) -> None:
+        self._client.logout_many(user_ids=user_ids)
+
+    def list_tags(self, user_id: int) -> list[str]:
+        return self._client.list_tags(user_id=user_id)
+
+    def set_tags(self, user_id: int, tags: Iterable[str]) -> list[str]:
+        return self._client.set_tags(user_id=user_id, tags=tags)
+
+    def add_tags(self, user_id: int, tags: Iterable[str]) -> list[str]:
+        return self._client.add_tags(user_id=user_id, tags=tags)
+
+    def remove_tags(self, user_id: int, tags: Iterable[str]) -> list[str]:
+        return self._client.remove_tags(user_id=user_id, tags=tags)

--- a/libzapi/domain/models/ticketing/user.py
+++ b/libzapi/domain/models/ticketing/user.py
@@ -13,43 +13,65 @@ class User:
     id: int
     url: str
     name: str
-    email: str
+    email: Optional[str]
     created_at: datetime
     updated_at: datetime
     time_zone: str
     iana_time_zone: str
-    phone: str
-    shared_phone_number: bool
+    phone: Optional[str]
+    shared_phone_number: Optional[bool]
     photo: Optional[Thumbnail]
     locale_id: int
     locale: str
     organization_id: Optional[OrganizationIdType]
     role: str
     verified: bool
-    external_id: str
+    external_id: Optional[str]
     tags: List[str]
-    alias: str
+    alias: Optional[str]
     active: bool
     shared: bool
     shared_agent: bool
-    last_login_at: datetime
+    last_login_at: Optional[datetime]
     two_factor_auth_enabled: bool
-    signature: str
-    details: str
-    notes: str
+    signature: Optional[str]
+    details: Optional[str]
+    notes: Optional[str]
     role_type: Optional[int]
     custom_role_id: Optional[int]
     is_billing_admin: bool
     moderator: bool
-    ticket_restriction: str
+    ticket_restriction: Optional[str]
     only_private_comments: bool
     restricted_agent: bool
     suspended: bool
     default_group_id: Optional[int]
     report_csv: bool
-    user_fields: dict
+    user_fields: Optional[dict] = None
 
     @property
     def logical_key(self) -> LogicalKey:
         base = f"id_{self.id}"
         return LogicalKey("user", base)
+
+
+@dataclass(frozen=True, slots=True)
+class UserRelated:
+    assigned_tickets: int = 0
+    requested_tickets: int = 0
+    ccd_tickets: int = 0
+    organization_subscriptions: int = 0
+    topic_comments: int = 0
+    topics: int = 0
+    votes: int = 0
+    subscriptions: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class ComplianceDeletionStatus:
+    account_subdomain: Optional[str] = None
+    action: Optional[str] = None
+    application: Optional[str] = None
+    created_at: Optional[datetime] = None
+    executer_id: Optional[int] = None
+    user_id: Optional[int] = None

--- a/libzapi/infrastructure/api_clients/ticketing/user_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/user_api_client.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
-from typing import Iterable
 
+from typing import Iterable, Iterator
+
+from libzapi.application.commands.ticketing.user_cmds import CreateUserCmd, UpdateUserCmd
+from libzapi.domain.models.ticketing.user import ComplianceDeletionStatus, User, UserRelated
 from libzapi.domain.shared_objects.count_snapshot import CountSnapshot
-from libzapi.infrastructure.mappers.count_mapper import to_count_snapshot
+from libzapi.domain.shared_objects.job_status import JobStatus
 from libzapi.infrastructure.http.client import HttpClient
 from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.mappers.count_mapper import to_count_snapshot
+from libzapi.infrastructure.mappers.ticketing.user_mapper import to_payload_create, to_payload_update
 from libzapi.infrastructure.serialization.parse import to_domain
-from libzapi.domain.models.ticketing.user import User
 
 
 class UserApiClient:
@@ -57,3 +61,159 @@ class UserApiClient:
     def get(self, user_id: int) -> User:
         data = self._http.get(f"/api/v2/users/{int(user_id)}")
         return to_domain(data=data["user"], cls=User)
+
+    def me(self) -> User:
+        data = self._http.get("/api/v2/users/me")
+        return to_domain(data=data["user"], cls=User)
+
+    def show_many(self, user_ids: Iterable[int]) -> Iterator[User]:
+        ids_str = ",".join(str(int(i)) for i in user_ids)
+        data = self._http.get(f"/api/v2/users/show_many?ids={ids_str}")
+        for obj in data["users"]:
+            yield to_domain(data=obj, cls=User)
+
+    def search(self, query: str | None = None, external_id: str | None = None) -> Iterator[User]:
+        if external_id is not None:
+            path = f"/api/v2/users/search?external_id={external_id}"
+        else:
+            path = f"/api/v2/users/search?query={query or ''}"
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path=path,
+            base_url=self._http.base_url,
+            items_key="users",
+        ):
+            yield to_domain(data=obj, cls=User)
+
+    def autocomplete(self, name: str) -> Iterator[User]:
+        data = self._http.post("/api/v2/users/autocomplete", {"name": name})
+        for obj in data.get("users", []):
+            yield to_domain(data=obj, cls=User)
+
+    def list_related(self, user_id: int) -> UserRelated:
+        data = self._http.get(f"/api/v2/users/{int(user_id)}/related")
+        return to_domain(data=data["user_related"], cls=UserRelated)
+
+    def list_compliance_deletion_statuses(
+        self, user_id: int
+    ) -> Iterator[ComplianceDeletionStatus]:
+        data = self._http.get(f"/api/v2/users/{int(user_id)}/compliance_deletion_statuses")
+        for obj in data.get("compliance_deletion_statuses", []):
+            yield to_domain(data=obj, cls=ComplianceDeletionStatus)
+
+    def list_deleted(self) -> Iterator[User]:
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path="/api/v2/deleted_users",
+            base_url=self._http.base_url,
+            items_key="deleted_users",
+        ):
+            yield to_domain(data=obj, cls=User)
+
+    def count_deleted(self) -> CountSnapshot:
+        data = self._http.get("/api/v2/deleted_users/count")
+        return to_count_snapshot(data["count"])
+
+    def show_deleted(self, deleted_user_id: int) -> User:
+        data = self._http.get(f"/api/v2/deleted_users/{int(deleted_user_id)}")
+        return to_domain(data=data["deleted_user"], cls=User)
+
+    def me_settings(self) -> dict:
+        data = self._http.get("/api/v2/users/me/settings")
+        return data.get("settings", data)
+
+    def update_me_settings(self, settings: dict) -> dict:
+        data = self._http.put("/api/v2/users/me/settings", {"settings": settings})
+        return data.get("settings", data)
+
+    def list_entitlements(self, user_id: int) -> list[dict]:
+        data = self._http.get(f"/api/v2/users/{int(user_id)}/entitlements/full")
+        return list(data.get("entitlements", []))
+
+    def create(self, entity: CreateUserCmd) -> User:
+        payload = to_payload_create(entity)
+        data = self._http.post("/api/v2/users", payload)
+        return to_domain(data=data["user"], cls=User)
+
+    def update(self, user_id: int, entity: UpdateUserCmd) -> User:
+        payload = to_payload_update(entity)
+        data = self._http.put(f"/api/v2/users/{int(user_id)}", payload)
+        return to_domain(data=data["user"], cls=User)
+
+    def delete(self, user_id: int) -> User:
+        data = self._http.delete(f"/api/v2/users/{int(user_id)}") or {}
+        return to_domain(data=data["user"], cls=User)
+
+    def create_many(self, entities: Iterable[CreateUserCmd]) -> JobStatus:
+        payload = {"users": [to_payload_create(e)["user"] for e in entities]}
+        data = self._http.post("/api/v2/users/create_many", payload)
+        return to_domain(data=data["job_status"], cls=JobStatus)
+
+    def create_or_update(self, entity: CreateUserCmd) -> User:
+        payload = to_payload_create(entity)
+        data = self._http.post("/api/v2/users/create_or_update", payload)
+        return to_domain(data=data["user"], cls=User)
+
+    def create_or_update_many(self, entities: Iterable[CreateUserCmd]) -> JobStatus:
+        payload = {"users": [to_payload_create(e)["user"] for e in entities]}
+        data = self._http.post("/api/v2/users/create_or_update_many", payload)
+        return to_domain(data=data["job_status"], cls=JobStatus)
+
+    def update_many(self, user_ids: Iterable[int], entity: UpdateUserCmd) -> JobStatus:
+        ids_str = ",".join(str(int(i)) for i in user_ids)
+        payload = to_payload_update(entity)
+        data = self._http.put(f"/api/v2/users/update_many?ids={ids_str}", payload)
+        return to_domain(data=data["job_status"], cls=JobStatus)
+
+    def update_many_individually(
+        self, updates: Iterable[tuple[int, UpdateUserCmd]]
+    ) -> JobStatus:
+        users = []
+        for user_id, cmd in updates:
+            user_payload = to_payload_update(cmd)["user"]
+            user_payload["id"] = int(user_id)
+            users.append(user_payload)
+        data = self._http.put("/api/v2/users/update_many", {"users": users})
+        return to_domain(data=data["job_status"], cls=JobStatus)
+
+    def destroy_many(self, user_ids: Iterable[int]) -> JobStatus:
+        ids_str = ",".join(str(int(i)) for i in user_ids)
+        data = self._http.delete(f"/api/v2/users/destroy_many?ids={ids_str}") or {}
+        return to_domain(data=data["job_status"], cls=JobStatus)
+
+    def merge(self, source_user_id: int, target_user_id: int) -> User:
+        data = self._http.put(
+            f"/api/v2/users/{int(source_user_id)}/merge",
+            {"user": {"id": int(target_user_id)}},
+        )
+        return to_domain(data=data["user"], cls=User)
+
+    def permanently_delete(self, deleted_user_id: int) -> User:
+        data = self._http.delete(f"/api/v2/deleted_users/{int(deleted_user_id)}") or {}
+        return to_domain(data=data["deleted_user"], cls=User)
+
+    def request_create(self, entity: CreateUserCmd) -> dict:
+        payload = to_payload_create(entity)
+        return self._http.post("/api/v2/users/request_create", payload)
+
+    def logout_many(self, user_ids: Iterable[int]) -> None:
+        ids_str = ",".join(str(int(i)) for i in user_ids)
+        self._http.post(f"/api/v2/users/logout_many?ids={ids_str}", {})
+
+    def list_tags(self, user_id: int) -> list[str]:
+        data = self._http.get(f"/api/v2/users/{int(user_id)}/tags")
+        return list(data.get("tags", []))
+
+    def set_tags(self, user_id: int, tags: Iterable[str]) -> list[str]:
+        data = self._http.post(f"/api/v2/users/{int(user_id)}/tags", {"tags": list(tags)})
+        return list(data.get("tags", []))
+
+    def add_tags(self, user_id: int, tags: Iterable[str]) -> list[str]:
+        data = self._http.put(f"/api/v2/users/{int(user_id)}/tags", {"tags": list(tags)})
+        return list(data.get("tags", []))
+
+    def remove_tags(self, user_id: int, tags: Iterable[str]) -> list[str]:
+        data = self._http.delete(
+            f"/api/v2/users/{int(user_id)}/tags", json={"tags": list(tags)}
+        )
+        return list((data or {}).get("tags", []))

--- a/libzapi/infrastructure/mappers/ticketing/user_mapper.py
+++ b/libzapi/infrastructure/mappers/ticketing/user_mapper.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from libzapi.application.commands.ticketing.user_cmds import CreateUserCmd, UpdateUserCmd
+
+
+_OPTIONAL_FIELDS = (
+    "email",
+    "role",
+    "phone",
+    "alias",
+    "external_id",
+    "organization_id",
+    "custom_role_id",
+    "default_group_id",
+    "details",
+    "notes",
+    "locale_id",
+    "time_zone",
+    "verified",
+    "active",
+    "moderator",
+    "only_private_comments",
+    "restricted_agent",
+    "suspended",
+    "ticket_restriction",
+    "user_fields",
+)
+
+
+def to_payload_create(cmd: CreateUserCmd) -> dict:
+    body: dict = {"name": cmd.name}
+    for field in _OPTIONAL_FIELDS:
+        value = getattr(cmd, field)
+        if value is not None:
+            body[field] = value
+    if cmd.tags is not None:
+        body["tags"] = list(cmd.tags)
+    return {"user": body}
+
+
+def to_payload_update(cmd: UpdateUserCmd) -> dict:
+    body: dict = {}
+    if cmd.name is not None:
+        body["name"] = cmd.name
+    for field in _OPTIONAL_FIELDS:
+        value = getattr(cmd, field)
+        if value is not None:
+            body[field] = value
+    if cmd.tags is not None:
+        body["tags"] = list(cmd.tags)
+    return {"user": body}

--- a/tests/integration/ticketing/test_user.py
+++ b/tests/integration/ticketing/test_user.py
@@ -1,6 +1,24 @@
 import itertools
+import uuid
+
+import pytest
 
 from libzapi import Ticketing
+
+
+def _unique() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+def _create_user(ticketing: Ticketing, **overrides):
+    suffix = _unique()
+    defaults = dict(
+        name=f"libzapi {suffix}",
+        email=f"libzapi-{suffix}@example.invalid",
+        role="end-user",
+    )
+    defaults.update(overrides)
+    return ticketing.users.create(**defaults)
 
 
 def test_list_and_get_user(ticketing: Ticketing):
@@ -8,3 +26,189 @@ def test_list_and_get_user(ticketing: Ticketing):
     assert len(objs) > 0
     obj = ticketing.users.get_by_id(objs[0].id)
     assert obj.id == objs[0].id
+
+
+def test_me(ticketing: Ticketing):
+    user = ticketing.users.me()
+    assert user.id > 0
+
+
+def test_create_update_delete_user(ticketing: Ticketing):
+    user = _create_user(ticketing, notes="created by libzapi integration test")
+    assert user.id > 0
+    updated = ticketing.users.update(user_id=user.id, name=f"{user.name} (updated)")
+    assert updated.name.endswith("(updated)")
+    deleted = ticketing.users.delete(user.id)
+    assert deleted.active is False
+
+
+def test_show_many(ticketing: Ticketing):
+    a = _create_user(ticketing)
+    b = _create_user(ticketing)
+    users = list(ticketing.users.show_many([a.id, b.id]))
+    ids = {u.id for u in users}
+    assert {a.id, b.id} <= ids
+
+
+def test_search_by_external_id(ticketing: Ticketing):
+    ext_id = f"libzapi-{_unique()}"
+    user = _create_user(ticketing, external_id=ext_id)
+    matches = list(ticketing.users.search(external_id=ext_id))
+    assert any(m.id == user.id for m in matches)
+
+
+def test_search_by_query(ticketing: Ticketing):
+    user = _create_user(ticketing)
+    matches = list(itertools.islice(ticketing.users.search(query=user.email), 25))
+    assert any(m.id == user.id for m in matches)
+
+
+def test_autocomplete(ticketing: Ticketing):
+    user = _create_user(ticketing)
+    matches = list(ticketing.users.autocomplete(name=user.name))
+    assert any(m.id == user.id for m in matches) or matches == []
+
+
+def test_list_related(ticketing: Ticketing):
+    me = ticketing.users.me()
+    related = ticketing.users.list_related(me.id)
+    assert related.requested_tickets >= 0
+
+
+def test_list_compliance_deletion_statuses(ticketing: Ticketing):
+    user = _create_user(ticketing)
+    statuses = list(ticketing.users.list_compliance_deletion_statuses(user.id))
+    assert isinstance(statuses, list)
+
+
+def test_me_settings(ticketing: Ticketing):
+    settings = ticketing.users.me_settings()
+    assert isinstance(settings, dict)
+
+
+def test_list_entitlements(ticketing: Ticketing):
+    me = ticketing.users.me()
+    try:
+        entitlements = ticketing.users.list_entitlements(me.id)
+    except Exception:
+        pytest.skip("entitlements endpoint not enabled on this tenant")
+    assert isinstance(entitlements, list)
+
+
+def test_create_many(ticketing: Ticketing):
+    job = ticketing.users.create_many(
+        [
+            {"name": f"libzapi bulk {_unique()}", "email": f"libzapi-{_unique()}@example.invalid"},
+            {"name": f"libzapi bulk {_unique()}", "email": f"libzapi-{_unique()}@example.invalid"},
+        ]
+    )
+    assert job.id
+
+
+def test_create_or_update(ticketing: Ticketing):
+    email = f"libzapi-cou-{_unique()}@example.invalid"
+    first = ticketing.users.create_or_update(name="libzapi cou", email=email)
+    second = ticketing.users.create_or_update(name="libzapi cou updated", email=email)
+    assert first.id == second.id
+
+
+def test_create_or_update_many(ticketing: Ticketing):
+    job = ticketing.users.create_or_update_many(
+        [
+            {"name": f"libzapi coum {_unique()}", "email": f"libzapi-{_unique()}@example.invalid"},
+            {"name": f"libzapi coum {_unique()}", "email": f"libzapi-{_unique()}@example.invalid"},
+        ]
+    )
+    assert job.id
+
+
+def test_update_many_uniform(ticketing: Ticketing):
+    a = _create_user(ticketing)
+    b = _create_user(ticketing)
+    job = ticketing.users.update_many([a.id, b.id], tags=["libzapi-um"])
+    assert job.id
+
+
+def test_update_many_individually(ticketing: Ticketing):
+    a = _create_user(ticketing)
+    b = _create_user(ticketing)
+    job = ticketing.users.update_many_individually(
+        [(a.id, {"tags": ["libzapi-umi-a"]}), (b.id, {"tags": ["libzapi-umi-b"]})]
+    )
+    assert job.id
+
+
+def test_destroy_many(ticketing: Ticketing):
+    a = _create_user(ticketing)
+    b = _create_user(ticketing)
+    job = ticketing.users.destroy_many([a.id, b.id])
+    assert job.id
+
+
+def test_merge_users(ticketing: Ticketing):
+    target = _create_user(ticketing)
+    source = _create_user(ticketing)
+    merged = ticketing.users.merge(source_user_id=source.id, target_user_id=target.id)
+    assert merged.id == target.id
+
+
+def test_list_and_count_deleted(ticketing: Ticketing):
+    user = _create_user(ticketing)
+    ticketing.users.delete(user.id)
+    count = ticketing.users.count_deleted()
+    assert count.value >= 1
+    deleted = list(itertools.islice(ticketing.users.list_deleted(), 100))
+    assert any(u.id == user.id for u in deleted) or deleted
+
+
+def test_show_deleted(ticketing: Ticketing):
+    user = _create_user(ticketing)
+    ticketing.users.delete(user.id)
+    shown = ticketing.users.show_deleted(user.id)
+    assert shown.id == user.id
+
+
+def test_permanently_delete(ticketing: Ticketing):
+    user = _create_user(ticketing)
+    ticketing.users.delete(user.id)
+    gone = ticketing.users.permanently_delete(user.id)
+    assert gone.id == user.id
+
+
+@pytest.mark.skip(reason="sends an invitation email; run manually when intended")
+def test_request_create(ticketing: Ticketing):
+    resp = ticketing.users.request_create(
+        name="libzapi invite", email=f"libzapi-inv-{_unique()}@example.invalid"
+    )
+    assert isinstance(resp, dict)
+
+
+def test_logout_many(ticketing: Ticketing):
+    a = _create_user(ticketing)
+    b = _create_user(ticketing)
+    ticketing.users.logout_many([a.id, b.id])
+
+
+def test_user_list_tags(ticketing: Ticketing):
+    user = _create_user(ticketing, tags=["libzapi-user-listtag"])
+    tags = ticketing.users.list_tags(user.id)
+    assert "libzapi-user-listtag" in tags
+
+
+def test_user_set_tags(ticketing: Ticketing):
+    user = _create_user(ticketing)
+    tags = ticketing.users.set_tags(user.id, ["libzapi-user-set"])
+    assert "libzapi-user-set" in tags
+
+
+def test_user_add_tags(ticketing: Ticketing):
+    user = _create_user(ticketing, tags=["libzapi-user-keep"])
+    tags = ticketing.users.add_tags(user.id, ["libzapi-user-added"])
+    assert {"libzapi-user-keep", "libzapi-user-added"} <= set(tags)
+
+
+def test_user_remove_tags(ticketing: Ticketing):
+    user = _create_user(ticketing, tags=["libzapi-user-keep", "libzapi-user-drop"])
+    tags = ticketing.users.remove_tags(user.id, ["libzapi-user-drop"])
+    assert "libzapi-user-drop" not in tags
+    assert "libzapi-user-keep" in tags

--- a/tests/unit/ticketing/test_user.py
+++ b/tests/unit/ticketing/test_user.py
@@ -2,6 +2,7 @@ import pytest
 from hypothesis import given
 from hypothesis.strategies import just, builds
 
+from libzapi.application.commands.ticketing.user_cmds import CreateUserCmd, UpdateUserCmd
 from libzapi.domain.models.ticketing.user import User
 from libzapi.domain.errors import NotFound, RateLimited, Unauthorized, UnprocessableEntity
 from libzapi.infrastructure.api_clients.ticketing import UserApiClient
@@ -77,3 +78,501 @@ def test_user_api_client_raises_on_http_error(error_cls, mocker):
 
     with pytest.raises(error_cls):
         client.get(1)
+
+
+# ---------------------------------------------------------------------------
+# read endpoints
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def http(mocker):
+    stub = mocker.Mock()
+    stub.base_url = "https://example.zendesk.com"
+    return stub
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.user_api_client.to_domain",
+        return_value=mocker.Mock(),
+    )
+
+
+def test_me_gets_users_me(http, domain):
+    http.get.return_value = {"user": {}}
+    client = UserApiClient(http)
+
+    client.me()
+
+    http.get.assert_called_once_with("/api/v2/users/me")
+
+
+def test_show_many_joins_ids(http, domain):
+    http.get.return_value = {"users": [{}, {}]}
+    client = UserApiClient(http)
+
+    list(client.show_many(user_ids=[1, 2, 3]))
+
+    http.get.assert_called_once_with("/api/v2/users/show_many?ids=1,2,3")
+
+
+def test_search_by_external_id(http, domain):
+    http.get.return_value = {"users": []}
+    client = UserApiClient(http)
+
+    list(client.search(external_id="ext-1"))
+
+    http.get.assert_called_with("/api/v2/users/search?external_id=ext-1")
+
+
+def test_search_by_query(http, domain):
+    http.get.return_value = {"users": []}
+    client = UserApiClient(http)
+
+    list(client.search(query="alice"))
+
+    http.get.assert_called_with("/api/v2/users/search?query=alice")
+
+
+def test_search_with_no_args_uses_empty_query(http, domain):
+    http.get.return_value = {"users": []}
+    client = UserApiClient(http)
+
+    list(client.search())
+
+    http.get.assert_called_with("/api/v2/users/search?query=")
+
+
+def test_autocomplete_posts_name(http, domain):
+    http.post.return_value = {"users": [{}]}
+    client = UserApiClient(http)
+
+    list(client.autocomplete(name="al"))
+
+    http.post.assert_called_once_with("/api/v2/users/autocomplete", {"name": "al"})
+
+
+def test_autocomplete_missing_users_key(http, domain):
+    http.post.return_value = {}
+    client = UserApiClient(http)
+
+    assert list(client.autocomplete(name="al")) == []
+
+
+def test_list_related(http, domain):
+    http.get.return_value = {"user_related": {"requested_tickets": 2}}
+    client = UserApiClient(http)
+
+    client.list_related(user_id=5)
+
+    http.get.assert_called_once_with("/api/v2/users/5/related")
+
+
+def test_list_compliance_deletion_statuses(http, domain):
+    http.get.return_value = {"compliance_deletion_statuses": [{}]}
+    client = UserApiClient(http)
+
+    list(client.list_compliance_deletion_statuses(user_id=5))
+
+    http.get.assert_called_once_with("/api/v2/users/5/compliance_deletion_statuses")
+
+
+def test_list_compliance_missing_key_returns_empty(http, domain):
+    http.get.return_value = {}
+    client = UserApiClient(http)
+
+    assert list(client.list_compliance_deletion_statuses(user_id=5)) == []
+
+
+@pytest.mark.parametrize(
+    "method, path",
+    [
+        ("count", "/api/v2/users/count"),
+    ],
+)
+def test_count_methods(method, path, http, domain):
+    http.get.return_value = {"count": {}}
+    mocker_patch = http  # keep name simple
+    client = UserApiClient(http)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "libzapi.infrastructure.api_clients.ticketing.user_api_client.to_count_snapshot",
+            lambda data: data,
+        )
+        getattr(client, method)()
+    mocker_patch.get.assert_called_with(path)
+
+
+def test_count_by_group(http, mocker):
+    http.get.return_value = {"count": {"value": 1}}
+    mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.user_api_client.to_count_snapshot",
+        return_value="snapshot",
+    )
+    client = UserApiClient(http)
+
+    assert client.count_by_group(group_id=11) == "snapshot"
+    http.get.assert_called_once_with("/api/v2/groups/11/users/count")
+
+
+def test_count_by_organization(http, mocker):
+    http.get.return_value = {"count": {"value": 2}}
+    mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.user_api_client.to_count_snapshot",
+        return_value="snapshot",
+    )
+    client = UserApiClient(http)
+
+    assert client.count_by_organization(organization_id=22) == "snapshot"
+    http.get.assert_called_once_with("/api/v2/organizations/22/users/count")
+
+
+# ---------------------------------------------------------------------------
+# create / update / delete
+# ---------------------------------------------------------------------------
+
+
+def test_create_posts_mapped_payload(http, domain):
+    http.post.return_value = {"user": {}}
+    client = UserApiClient(http)
+
+    client.create(entity=CreateUserCmd(name="n", email="e@x.y"))
+
+    path, payload = http.post.call_args.args
+    assert path == "/api/v2/users"
+    assert payload == {"user": {"name": "n", "email": "e@x.y"}}
+
+
+def test_update_puts_mapped_payload(http, domain):
+    http.put.return_value = {"user": {}}
+    client = UserApiClient(http)
+
+    client.update(user_id=42, entity=UpdateUserCmd(name="new"))
+
+    path, payload = http.put.call_args.args
+    assert path == "/api/v2/users/42"
+    assert payload == {"user": {"name": "new"}}
+
+
+def test_delete_returns_domain(http, domain):
+    http.delete.return_value = {"user": {}}
+    client = UserApiClient(http)
+
+    client.delete(user_id=42)
+
+    http.delete.assert_called_once_with("/api/v2/users/42")
+
+
+def test_delete_handles_empty_response(http, domain):
+    http.delete.return_value = None
+    client = UserApiClient(http)
+
+    with pytest.raises(KeyError):
+        client.delete(user_id=42)
+
+
+# ---------------------------------------------------------------------------
+# bulk operations
+# ---------------------------------------------------------------------------
+
+
+def test_create_many_posts_list_body(http, domain):
+    http.post.return_value = {"job_status": {}}
+    client = UserApiClient(http)
+
+    client.create_many(entities=[CreateUserCmd(name="a"), CreateUserCmd(name="b")])
+
+    path, payload = http.post.call_args.args
+    assert path == "/api/v2/users/create_many"
+    assert payload == {"users": [{"name": "a"}, {"name": "b"}]}
+
+
+def test_create_or_update(http, domain):
+    http.post.return_value = {"user": {}}
+    client = UserApiClient(http)
+
+    client.create_or_update(entity=CreateUserCmd(name="n", email="e@x.y"))
+
+    http.post.assert_called_once_with(
+        "/api/v2/users/create_or_update", {"user": {"name": "n", "email": "e@x.y"}}
+    )
+
+
+def test_create_or_update_many(http, domain):
+    http.post.return_value = {"job_status": {}}
+    client = UserApiClient(http)
+
+    client.create_or_update_many(entities=[CreateUserCmd(name="a")])
+
+    path, payload = http.post.call_args.args
+    assert path == "/api/v2/users/create_or_update_many"
+    assert payload == {"users": [{"name": "a"}]}
+
+
+def test_update_many_uniform(http, domain):
+    http.put.return_value = {"job_status": {}}
+    client = UserApiClient(http)
+
+    client.update_many(user_ids=[1, 2], entity=UpdateUserCmd(role="agent"))
+
+    path, payload = http.put.call_args.args
+    assert path == "/api/v2/users/update_many?ids=1,2"
+    assert payload == {"user": {"role": "agent"}}
+
+
+def test_update_many_individually_embeds_ids(http, domain):
+    http.put.return_value = {"job_status": {}}
+    client = UserApiClient(http)
+
+    client.update_many_individually(
+        updates=[(1, UpdateUserCmd(role="admin")), (2, UpdateUserCmd(name="n"))]
+    )
+
+    path, payload = http.put.call_args.args
+    assert path == "/api/v2/users/update_many"
+    assert payload["users"][0]["id"] == 1
+    assert payload["users"][0]["role"] == "admin"
+    assert payload["users"][1]["id"] == 2
+    assert payload["users"][1]["name"] == "n"
+
+
+def test_destroy_many(http, domain):
+    http.delete.return_value = {"job_status": {}}
+    client = UserApiClient(http)
+
+    client.destroy_many(user_ids=[5, 6])
+
+    http.delete.assert_called_once_with("/api/v2/users/destroy_many?ids=5,6")
+
+
+def test_destroy_many_empty_response(http, domain):
+    http.delete.return_value = None
+    client = UserApiClient(http)
+
+    with pytest.raises(KeyError):
+        client.destroy_many(user_ids=[1])
+
+
+def test_merge_puts_target_user(http, domain):
+    http.put.return_value = {"user": {}}
+    client = UserApiClient(http)
+
+    client.merge(source_user_id=1, target_user_id=2)
+
+    path, payload = http.put.call_args.args
+    assert path == "/api/v2/users/1/merge"
+    assert payload == {"user": {"id": 2}}
+
+
+# ---------------------------------------------------------------------------
+# deleted users
+# ---------------------------------------------------------------------------
+
+
+def test_list_deleted(http, domain):
+    http.get.return_value = {"deleted_users": []}
+    client = UserApiClient(http)
+
+    list(client.list_deleted())
+
+    http.get.assert_called_with("/api/v2/deleted_users")
+
+
+def test_count_deleted(http, mocker):
+    http.get.return_value = {"count": {"value": 3}}
+    mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.user_api_client.to_count_snapshot",
+        return_value="snap",
+    )
+    client = UserApiClient(http)
+
+    assert client.count_deleted() == "snap"
+    http.get.assert_called_once_with("/api/v2/deleted_users/count")
+
+
+def test_show_deleted(http, domain):
+    http.get.return_value = {"deleted_user": {}}
+    client = UserApiClient(http)
+
+    client.show_deleted(deleted_user_id=11)
+
+    http.get.assert_called_once_with("/api/v2/deleted_users/11")
+
+
+def test_permanently_delete(http, domain):
+    http.delete.return_value = {"deleted_user": {}}
+    client = UserApiClient(http)
+
+    client.permanently_delete(deleted_user_id=11)
+
+    http.delete.assert_called_once_with("/api/v2/deleted_users/11")
+
+
+def test_permanently_delete_empty_response(http, domain):
+    http.delete.return_value = None
+    client = UserApiClient(http)
+
+    with pytest.raises(KeyError):
+        client.permanently_delete(deleted_user_id=11)
+
+
+# ---------------------------------------------------------------------------
+# settings / entitlements / other misc
+# ---------------------------------------------------------------------------
+
+
+def test_me_settings_returns_nested_settings(http):
+    http.get.return_value = {"settings": {"theme": "dark"}}
+    client = UserApiClient(http)
+    assert client.me_settings() == {"theme": "dark"}
+
+
+def test_me_settings_falls_back_to_raw(http):
+    http.get.return_value = {"theme": "dark"}
+    client = UserApiClient(http)
+    assert client.me_settings() == {"theme": "dark"}
+
+
+def test_update_me_settings_puts_body(http):
+    http.put.return_value = {"settings": {"theme": "light"}}
+    client = UserApiClient(http)
+
+    assert client.update_me_settings(settings={"theme": "light"}) == {"theme": "light"}
+    http.put.assert_called_once_with(
+        "/api/v2/users/me/settings", {"settings": {"theme": "light"}}
+    )
+
+
+def test_update_me_settings_falls_back_to_raw(http):
+    http.put.return_value = {"ok": True}
+    client = UserApiClient(http)
+
+    assert client.update_me_settings(settings={}) == {"ok": True}
+
+
+def test_list_entitlements(http):
+    http.get.return_value = {"entitlements": [{"id": 1}]}
+    client = UserApiClient(http)
+
+    assert client.list_entitlements(user_id=5) == [{"id": 1}]
+    http.get.assert_called_once_with("/api/v2/users/5/entitlements/full")
+
+
+def test_list_entitlements_missing_key_returns_empty(http):
+    http.get.return_value = {}
+    client = UserApiClient(http)
+
+    assert client.list_entitlements(user_id=5) == []
+
+
+def test_request_create_returns_raw(http):
+    http.post.return_value = {"status": "ok"}
+    client = UserApiClient(http)
+
+    result = client.request_create(entity=CreateUserCmd(name="n", email="e@x.y"))
+
+    assert result == {"status": "ok"}
+    http.post.assert_called_once_with(
+        "/api/v2/users/request_create", {"user": {"name": "n", "email": "e@x.y"}}
+    )
+
+
+def test_logout_many_posts_empty_body(http):
+    client = UserApiClient(http)
+
+    client.logout_many(user_ids=[1, 2])
+
+    http.post.assert_called_once_with("/api/v2/users/logout_many?ids=1,2", {})
+
+
+# ---------------------------------------------------------------------------
+# tags
+# ---------------------------------------------------------------------------
+
+
+def test_list_tags_returns_list(http):
+    http.get.return_value = {"tags": ["a"]}
+    client = UserApiClient(http)
+
+    assert client.list_tags(user_id=5) == ["a"]
+    http.get.assert_called_once_with("/api/v2/users/5/tags")
+
+
+def test_list_tags_missing_key(http):
+    http.get.return_value = {}
+    client = UserApiClient(http)
+    assert client.list_tags(user_id=5) == []
+
+
+def test_set_tags(http):
+    http.post.return_value = {"tags": ["a"]}
+    client = UserApiClient(http)
+
+    assert client.set_tags(user_id=5, tags=["a"]) == ["a"]
+    http.post.assert_called_once_with("/api/v2/users/5/tags", {"tags": ["a"]})
+
+
+def test_add_tags(http):
+    http.put.return_value = {"tags": ["a", "b"]}
+    client = UserApiClient(http)
+
+    assert client.add_tags(user_id=5, tags=["b"]) == ["a", "b"]
+    http.put.assert_called_once_with("/api/v2/users/5/tags", {"tags": ["b"]})
+
+
+def test_remove_tags_sends_body_with_delete(http):
+    http.delete.return_value = {"tags": ["a"]}
+    client = UserApiClient(http)
+
+    assert client.remove_tags(user_id=5, tags=["b"]) == ["a"]
+    http.delete.assert_called_once_with("/api/v2/users/5/tags", json={"tags": ["b"]})
+
+
+def test_remove_tags_handles_empty_response(http):
+    http.delete.return_value = None
+    client = UserApiClient(http)
+
+    assert client.remove_tags(user_id=5, tags=["b"]) == []
+
+
+# ---------------------------------------------------------------------------
+# Iterator bodies: non-empty responses exercise the `yield to_domain(...)` path
+# ---------------------------------------------------------------------------
+
+
+def test_list_all_yields_domain_per_user(http, domain):
+    http.get.return_value = {"users": [{"id": 1}, {"id": 2}]}
+    client = UserApiClient(http)
+
+    assert len(list(client.list_all())) == 2
+
+
+def test_list_by_group_yields_domain(http, domain):
+    http.get.return_value = {"users": [{"id": 1}]}
+    client = UserApiClient(http)
+
+    assert len(list(client.list_by_group(1))) == 1
+
+
+def test_list_by_organization_yields_domain(http, domain):
+    http.get.return_value = {"users": [{"id": 1}]}
+    client = UserApiClient(http)
+
+    assert len(list(client.list_by_organization(1))) == 1
+
+
+def test_search_yields_domain(http, domain):
+    http.get.return_value = {"users": [{"id": 1}]}
+    client = UserApiClient(http)
+
+    assert len(list(client.search(query="alice"))) == 1
+
+
+def test_list_deleted_yields_domain(http, domain):
+    http.get.return_value = {"deleted_users": [{"id": 1}]}
+    client = UserApiClient(http)
+
+    assert len(list(client.list_deleted())) == 1

--- a/tests/unit/ticketing/test_user_mapper.py
+++ b/tests/unit/ticketing/test_user_mapper.py
@@ -1,0 +1,142 @@
+from libzapi.application.commands.ticketing.user_cmds import CreateUserCmd, UpdateUserCmd
+from libzapi.infrastructure.mappers.ticketing.user_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
+
+
+# ---------------------------------------------------------------------------
+# to_payload_create
+# ---------------------------------------------------------------------------
+
+
+def test_create_minimal_only_has_name():
+    cmd = CreateUserCmd(name="alice")
+    assert to_payload_create(cmd) == {"user": {"name": "alice"}}
+
+
+def test_create_includes_optional_fields_when_set():
+    cmd = CreateUserCmd(
+        name="alice",
+        email="a@x.y",
+        role="agent",
+        phone="+1",
+        alias="ali",
+        external_id="ext-1",
+        organization_id=7,
+        custom_role_id=3,
+        default_group_id=4,
+        details="d",
+        notes="n",
+        locale_id=1,
+        time_zone="UTC",
+        verified=True,
+        active=True,
+        moderator=False,
+        only_private_comments=False,
+        restricted_agent=False,
+        suspended=False,
+        ticket_restriction="assigned",
+        user_fields={"k": "v"},
+    )
+
+    body = to_payload_create(cmd)["user"]
+    assert body["name"] == "alice"
+    assert body["email"] == "a@x.y"
+    assert body["role"] == "agent"
+    assert body["phone"] == "+1"
+    assert body["alias"] == "ali"
+    assert body["external_id"] == "ext-1"
+    assert body["organization_id"] == 7
+    assert body["custom_role_id"] == 3
+    assert body["default_group_id"] == 4
+    assert body["details"] == "d"
+    assert body["notes"] == "n"
+    assert body["locale_id"] == 1
+    assert body["time_zone"] == "UTC"
+    assert body["verified"] is True
+    assert body["active"] is True
+    assert body["moderator"] is False
+    assert body["only_private_comments"] is False
+    assert body["restricted_agent"] is False
+    assert body["suspended"] is False
+    assert body["ticket_restriction"] == "assigned"
+    assert body["user_fields"] == {"k": "v"}
+
+
+def test_create_tags_converted_to_list():
+    cmd = CreateUserCmd(name="n", tags=("a", "b"))
+    body = to_payload_create(cmd)["user"]
+    assert body["tags"] == ["a", "b"]
+
+
+def test_create_omits_none_fields():
+    body = to_payload_create(CreateUserCmd(name="n"))["user"]
+    assert list(body.keys()) == ["name"]
+
+
+def test_create_preserves_false_boolean_values():
+    body = to_payload_create(CreateUserCmd(name="n", verified=False))["user"]
+    # verified=False must be preserved (None would be omitted, but False is a set value)
+    assert body["verified"] is False
+
+
+# ---------------------------------------------------------------------------
+# to_payload_update
+# ---------------------------------------------------------------------------
+
+
+def test_update_empty_cmd_yields_empty_body():
+    assert to_payload_update(UpdateUserCmd()) == {"user": {}}
+
+
+def test_update_includes_name_when_set():
+    body = to_payload_update(UpdateUserCmd(name="n"))["user"]
+    assert body == {"name": "n"}
+
+
+def test_update_omits_none_fields():
+    body = to_payload_update(UpdateUserCmd(email="e@x.y"))["user"]
+    assert body == {"email": "e@x.y"}
+
+
+def test_update_tags_converted_to_list():
+    body = to_payload_update(UpdateUserCmd(tags=("a", "b")))["user"]
+    assert body["tags"] == ["a", "b"]
+
+
+def test_update_preserves_false_booleans():
+    body = to_payload_update(UpdateUserCmd(suspended=False))["user"]
+    assert body == {"suspended": False}
+
+
+def test_update_all_fields_together():
+    cmd = UpdateUserCmd(
+        name="n",
+        email="e@x.y",
+        role="agent",
+        phone="+1",
+        alias="a",
+        external_id="ext",
+        organization_id=1,
+        custom_role_id=2,
+        default_group_id=3,
+        details="d",
+        notes="x",
+        locale_id=4,
+        time_zone="UTC",
+        verified=True,
+        active=True,
+        moderator=True,
+        only_private_comments=True,
+        restricted_agent=True,
+        suspended=True,
+        ticket_restriction="organization",
+        tags=["a"],
+        user_fields={"k": 1},
+    )
+    body = to_payload_update(cmd)["user"]
+    assert body["name"] == "n"
+    assert body["ticket_restriction"] == "organization"
+    assert body["tags"] == ["a"]
+    assert body["user_fields"] == {"k": 1}

--- a/tests/unit/ticketing/test_users_service.py
+++ b/tests/unit/ticketing/test_users_service.py
@@ -1,0 +1,312 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.commands.ticketing.user_cmds import CreateUserCmd, UpdateUserCmd
+from libzapi.application.services.ticketing.users_service import UsersService
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return UsersService(client), client
+
+
+# ---------------------------------------------------------------------------
+# simple delegation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method",
+    ["list_all", "count", "me", "me_settings", "list_deleted", "count_deleted"],
+)
+def test_no_arg_delegation(method):
+    service, client = _make_service()
+    getattr(client, method).return_value = sentinel.result
+
+    result = getattr(service, method)()
+
+    getattr(client, method).assert_called_once_with()
+    assert result is sentinel.result
+
+
+@pytest.mark.parametrize(
+    "method, arg",
+    [
+        ("list_by_group", 11),
+        ("list_by_organization", 22),
+        ("count_by_group", 11),
+        ("count_by_organization", 22),
+    ],
+)
+def test_positional_id_delegation(method, arg):
+    service, client = _make_service()
+    getattr(client, method).return_value = sentinel.result
+
+    result = getattr(service, method)(arg)
+
+    getattr(client, method).assert_called_once_with(arg)
+    assert result is sentinel.result
+
+
+def test_get_by_id_delegates_to_get():
+    service, client = _make_service()
+    client.get.return_value = sentinel.user
+
+    assert service.get_by_id(5) is sentinel.user
+    client.get.assert_called_once_with(5)
+
+
+def test_show_many_delegates():
+    service, client = _make_service()
+    client.show_many.return_value = sentinel.users
+
+    assert service.show_many([1, 2]) is sentinel.users
+    client.show_many.assert_called_once_with(user_ids=[1, 2])
+
+
+def test_search_passes_kwargs():
+    service, client = _make_service()
+    service.search(query="q", external_id="ext")
+    client.search.assert_called_once_with(query="q", external_id="ext")
+
+
+def test_autocomplete_passes_name():
+    service, client = _make_service()
+    service.autocomplete(name="al")
+    client.autocomplete.assert_called_once_with(name="al")
+
+
+def test_list_related_passes_user_id():
+    service, client = _make_service()
+    service.list_related(user_id=5)
+    client.list_related.assert_called_once_with(user_id=5)
+
+
+def test_list_compliance_passes_user_id():
+    service, client = _make_service()
+    service.list_compliance_deletion_statuses(user_id=5)
+    client.list_compliance_deletion_statuses.assert_called_once_with(user_id=5)
+
+
+def test_show_deleted_passes_id():
+    service, client = _make_service()
+    service.show_deleted(deleted_user_id=11)
+    client.show_deleted.assert_called_once_with(deleted_user_id=11)
+
+
+def test_update_me_settings_passes_dict():
+    service, client = _make_service()
+    service.update_me_settings({"k": "v"})
+    client.update_me_settings.assert_called_once_with(settings={"k": "v"})
+
+
+def test_list_entitlements_passes_user_id():
+    service, client = _make_service()
+    service.list_entitlements(user_id=5)
+    client.list_entitlements.assert_called_once_with(user_id=5)
+
+
+def test_merge_passes_source_target():
+    service, client = _make_service()
+    service.merge(source_user_id=1, target_user_id=2)
+    client.merge.assert_called_once_with(source_user_id=1, target_user_id=2)
+
+
+def test_permanently_delete_passes_id():
+    service, client = _make_service()
+    service.permanently_delete(deleted_user_id=11)
+    client.permanently_delete.assert_called_once_with(deleted_user_id=11)
+
+
+def test_logout_many_passes_ids():
+    service, client = _make_service()
+    service.logout_many([1, 2])
+    client.logout_many.assert_called_once_with(user_ids=[1, 2])
+
+
+# ---------------------------------------------------------------------------
+# cmd-building methods
+# ---------------------------------------------------------------------------
+
+
+class TestCreate:
+    def test_builds_create_user_cmd(self):
+        service, client = _make_service()
+        client.create.return_value = sentinel.user
+
+        result = service.create(name="n", email="e@x.y", role="end-user", tags=["a"])
+
+        entity = client.create.call_args.kwargs["entity"]
+        assert isinstance(entity, CreateUserCmd)
+        assert entity.name == "n"
+        assert entity.email == "e@x.y"
+        assert entity.role == "end-user"
+        assert entity.tags == ["a"]
+        assert result is sentinel.user
+
+    def test_requires_name(self):
+        service, _ = _make_service()
+        with pytest.raises(TypeError):
+            service.create(email="e@x.y")
+
+
+class TestUpdate:
+    def test_builds_update_user_cmd(self):
+        service, client = _make_service()
+        client.update.return_value = sentinel.user
+
+        result = service.update(user_id=5, name="new")
+
+        assert client.update.call_args.kwargs["user_id"] == 5
+        entity = client.update.call_args.kwargs["entity"]
+        assert isinstance(entity, UpdateUserCmd)
+        assert entity.name == "new"
+        assert result is sentinel.user
+
+    def test_update_with_no_fields_yields_blank_cmd(self):
+        service, client = _make_service()
+        service.update(user_id=5)
+        entity = client.update.call_args.kwargs["entity"]
+        assert entity.name is None
+
+
+def test_delete_delegates():
+    service, client = _make_service()
+    client.delete.return_value = sentinel.user
+
+    assert service.delete(5) is sentinel.user
+    client.delete.assert_called_once_with(user_id=5)
+
+
+class TestCreateMany:
+    def test_converts_list_of_dicts(self):
+        service, client = _make_service()
+        client.create_many.return_value = sentinel.job
+
+        result = service.create_many(
+            [{"name": "a", "email": "a@x.y"}, {"name": "b"}]
+        )
+
+        entities = client.create_many.call_args.kwargs["entities"]
+        assert len(entities) == 2
+        assert all(isinstance(e, CreateUserCmd) for e in entities)
+        assert entities[0].name == "a"
+        assert entities[0].email == "a@x.y"
+        assert entities[1].name == "b"
+        assert result is sentinel.job
+
+
+def test_create_or_update_builds_cmd():
+    service, client = _make_service()
+    service.create_or_update(name="n", email="e@x.y")
+    entity = client.create_or_update.call_args.kwargs["entity"]
+    assert isinstance(entity, CreateUserCmd)
+    assert entity.name == "n"
+
+
+def test_create_or_update_many_builds_list():
+    service, client = _make_service()
+    service.create_or_update_many([{"name": "a"}])
+    entities = client.create_or_update_many.call_args.kwargs["entities"]
+    assert len(entities) == 1
+    assert entities[0].name == "a"
+
+
+class TestUpdateMany:
+    def test_update_many_builds_update_cmd(self):
+        service, client = _make_service()
+        client.update_many.return_value = sentinel.job
+
+        service.update_many([1, 2], tags=["a"])
+
+        assert client.update_many.call_args.kwargs["user_ids"] == [1, 2]
+        entity = client.update_many.call_args.kwargs["entity"]
+        assert isinstance(entity, UpdateUserCmd)
+        assert entity.tags == ["a"]
+
+    def test_update_many_individually_builds_pairs(self):
+        service, client = _make_service()
+        client.update_many_individually.return_value = sentinel.job
+
+        service.update_many_individually(
+            [(1, {"tags": ["x"]}), (2, {"role": "agent"})]
+        )
+
+        pairs = client.update_many_individually.call_args.kwargs["updates"]
+        assert pairs[0][0] == 1
+        assert isinstance(pairs[0][1], UpdateUserCmd)
+        assert pairs[0][1].tags == ["x"]
+        assert pairs[1][1].role == "agent"
+
+
+def test_destroy_many_delegates():
+    service, client = _make_service()
+    service.destroy_many([1, 2])
+    client.destroy_many.assert_called_once_with(user_ids=[1, 2])
+
+
+def test_request_create_builds_cmd():
+    service, client = _make_service()
+    client.request_create.return_value = {"ok": True}
+
+    assert service.request_create(name="n", email="e@x.y") == {"ok": True}
+    entity = client.request_create.call_args.kwargs["entity"]
+    assert isinstance(entity, CreateUserCmd)
+    assert entity.name == "n"
+
+
+# ---------------------------------------------------------------------------
+# tag helpers
+# ---------------------------------------------------------------------------
+
+
+def test_list_tags_delegates():
+    service, client = _make_service()
+    client.list_tags.return_value = ["a"]
+    assert service.list_tags(5) == ["a"]
+    client.list_tags.assert_called_once_with(user_id=5)
+
+
+def test_set_tags_delegates():
+    service, client = _make_service()
+    client.set_tags.return_value = ["a"]
+    assert service.set_tags(5, ["a"]) == ["a"]
+    client.set_tags.assert_called_once_with(user_id=5, tags=["a"])
+
+
+def test_add_tags_delegates():
+    service, client = _make_service()
+    client.add_tags.return_value = ["a", "b"]
+    assert service.add_tags(5, ["b"]) == ["a", "b"]
+    client.add_tags.assert_called_once_with(user_id=5, tags=["b"])
+
+
+def test_remove_tags_delegates():
+    service, client = _make_service()
+    client.remove_tags.return_value = ["a"]
+    assert service.remove_tags(5, ["b"]) == ["a"]
+    client.remove_tags.assert_called_once_with(user_id=5, tags=["b"])
+
+
+# ---------------------------------------------------------------------------
+# error propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+def test_create_propagates_error(error_cls):
+    service, client = _make_service()
+    client.create.side_effect = error_cls("boom")
+
+    with pytest.raises(error_cls):
+        service.create(name="n")
+
+
+@pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+def test_list_all_propagates_error(error_cls):
+    service, client = _make_service()
+    client.list_all.side_effect = error_cls("boom")
+
+    with pytest.raises(error_cls):
+        service.list_all()


### PR DESCRIPTION
## Summary
- Implements the Users portion of the Zendesk Ticketing API: create / update / delete (single and bulk), `create_or_update`, `update_many` uniform and individually, `destroy_many`, `merge`, and `permanently_delete`.
- Adds user lookup surfaces: `show_many`, `search` (by query or `external_id`), `autocomplete`, `list_related`, `list_compliance_deletion_statuses`, `list_entitlements`, `list_deleted` / `count_deleted` / `show_deleted`, `me_settings` / `update_me_settings`, `logout_many`, `request_create`, and list/set/add/remove tags.
- Relaxes several `User` domain fields to `Optional` to match the shape Zendesk returns for freshly-created users, and adds `UserRelated` and `ComplianceDeletionStatus` models plus `CreateUserCmd` / `UpdateUserCmd` command dataclasses with matching payload mappers.

## Dependencies
- Stacks on top of #77 (tickets CUD) — needs the extended `HttpClient.delete(json=...)` for `remove_tags`. Merge #77 first, then rebase this onto `main`.

## Test plan
- [x] `uv run --python 3.12 pytest tests/unit -q` → 1445 passed
- [x] `pytest tests/integration/ticketing/test_user.py --collect-only -q` → 27 tests collected
- [ ] Live-tenant integration run (`pytest tests/integration/ticketing/test_user.py`) against a sandbox Zendesk instance — not executed in this PR, run before merge.
- [ ] `test_request_create` is `@pytest.mark.skip` (would send real invitation emails); `test_list_entitlements` falls back to `pytest.skip` when Sell/entitlements isn't enabled on the tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)