### PR TITLE
feat(ticketing): add group memberships + groups kwargs ergonomics

### DIFF
--- a/libzapi/application/commands/ticketing/group_membership_cmds.py
+++ b/libzapi/application/commands/ticketing/group_membership_cmds.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class CreateGroupMembershipCmd:
+    user_id: int
+    group_id: int
+    default: bool | None = None

--- a/libzapi/application/services/ticketing/__init__.py
+++ b/libzapi/application/services/ticketing/__init__.py
@@ -6,6 +6,9 @@ from libzapi.application.services.ticketing.brand_agents_service import BrandAge
 from libzapi.application.services.ticketing.brands_service import BrandsService
 from libzapi.application.services.ticketing.email_notifications_service import EmailNotificationService
 from libzapi.application.services.ticketing.groups_service import GroupsService
+from libzapi.application.services.ticketing.group_memberships_service import (
+    GroupMembershipsService,
+)
 from libzapi.application.services.ticketing.macro_service import MacroService
 from libzapi.application.services.ticketing.organizations_service import OrganizationsService
 from libzapi.application.services.ticketing.requests_service import RequestsService
@@ -50,6 +53,7 @@ class Ticketing:
         self.brand_agents = BrandAgentsService(api.BrandAgentApiClient(http))
         self.email_notifications = EmailNotificationService(api.EmailNotificationApiClient(http))
         self.groups = GroupsService(api.GroupApiClient(http))
+        self.group_memberships = GroupMembershipsService(api.GroupMembershipApiClient(http))
         self.macros = MacroService(api.MacroApiClient(http))
         self.organizations = OrganizationsService(api.OrganizationApiClient(http))
         self.requests = RequestsService(api.RequestApiClient(http))

--- a/libzapi/application/services/ticketing/group_memberships_service.py
+++ b/libzapi/application/services/ticketing/group_memberships_service.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from libzapi.application.commands.ticketing.group_membership_cmds import (
+    CreateGroupMembershipCmd,
+)
+from libzapi.domain.models.ticketing.group_membership import GroupMembership
+from libzapi.domain.shared_objects.job_status import JobStatus
+from libzapi.infrastructure.api_clients.ticketing.group_membership_api_client import (
+    GroupMembershipApiClient,
+)
+
+
+class GroupMembershipsService:
+    """High-level service using the API client."""
+
+    def __init__(self, client: GroupMembershipApiClient) -> None:
+        self._client = client
+
+    def list_all(self) -> Iterable[GroupMembership]:
+        return self._client.list()
+
+    def list_by_user(self, user_id: int) -> Iterable[GroupMembership]:
+        return self._client.list_by_user(user_id)
+
+    def list_by_group(self, group_id: int) -> Iterable[GroupMembership]:
+        return self._client.list_by_group(group_id)
+
+    def list_assignable(self, group_id: int) -> Iterable[GroupMembership]:
+        return self._client.list_assignable(group_id)
+
+    def list_assignable_for_user(self, user_id: int) -> Iterable[GroupMembership]:
+        return self._client.list_assignable_for_user(user_id)
+
+    def get_by_id(self, membership_id: int) -> GroupMembership:
+        return self._client.get(membership_id)
+
+    def get_for_user(self, user_id: int, membership_id: int) -> GroupMembership:
+        return self._client.get_for_user(user_id, membership_id)
+
+    def create(self, user_id: int, group_id: int, default: bool | None = None) -> GroupMembership:
+        return self._client.create(
+            entity=CreateGroupMembershipCmd(
+                user_id=user_id, group_id=group_id, default=default
+            )
+        )
+
+    def create_for_user(
+        self, user_id: int, group_id: int, default: bool | None = None
+    ) -> GroupMembership:
+        return self._client.create_for_user(
+            user_id=user_id,
+            entity=CreateGroupMembershipCmd(
+                user_id=user_id, group_id=group_id, default=default
+            ),
+        )
+
+    def delete(self, membership_id: int) -> None:
+        self._client.delete(membership_id)
+
+    def delete_for_user(self, user_id: int, membership_id: int) -> None:
+        self._client.delete_for_user(user_id, membership_id)
+
+    def make_default(self, user_id: int, membership_id: int) -> list[GroupMembership]:
+        return self._client.make_default(user_id, membership_id)
+
+    def create_many(self, memberships: Iterable[dict]) -> JobStatus:
+        return self._client.create_many(
+            entities=[CreateGroupMembershipCmd(**m) for m in memberships]
+        )
+
+    def destroy_many(self, membership_ids: Iterable[int]) -> JobStatus:
+        return self._client.destroy_many(membership_ids=membership_ids)

--- a/libzapi/application/services/ticketing/groups_service.py
+++ b/libzapi/application/services/ticketing/groups_service.py
@@ -1,8 +1,13 @@
+from __future__ import annotations
+
 from typing import Iterable
 
-from libzapi.application.commands.ticketing.group_cmds import CreateGroupCmd, UpdateGroupCmd
-from libzapi.domain.shared_objects.count_snapshot import CountSnapshot
+from libzapi.application.commands.ticketing.group_cmds import (
+    CreateGroupCmd,
+    UpdateGroupCmd,
+)
 from libzapi.domain.models.ticketing.group import Group
+from libzapi.domain.shared_objects.count_snapshot import CountSnapshot
 from libzapi.infrastructure.api_clients.ticketing.group_api_client import GroupApiClient
 
 
@@ -27,14 +32,19 @@ class GroupsService:
     def count_user(self, user_id: int) -> CountSnapshot:
         return self._client.count_user(user_id)
 
+    def count_assignable(self) -> CountSnapshot:
+        return self._client.count_assignable()
+
     def get_by_id(self, group_id: int) -> Group:
         return self._client.get(group_id)
 
-    def create(self, entity: CreateGroupCmd) -> Group:
-        return self._client.create(entity)
+    def create(self, **fields) -> Group:
+        return self._client.create(entity=CreateGroupCmd(**fields))
 
-    def update(self, group_id: int, entity: UpdateGroupCmd) -> Group:
-        return self._client.update(group_id, entity)
+    def update(self, group_id: int, **fields) -> Group:
+        return self._client.update(
+            group_id=group_id, entity=UpdateGroupCmd(**fields)
+        )
 
     def delete(self, group_id: int) -> None:
         self._client.delete(group_id)

--- a/libzapi/domain/models/ticketing/group_membership.py
+++ b/libzapi/domain/models/ticketing/group_membership.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from libzapi.domain.shared_objects.logical_key import LogicalKey
+
+
+@dataclass(frozen=True, slots=True)
+class GroupMembership:
+    id: int
+    user_id: int
+    group_id: int
+    default: bool
+    created_at: datetime
+    updated_at: datetime
+    url: Optional[str] = None
+
+    @property
+    def logical_key(self) -> LogicalKey:
+        return LogicalKey("group_membership", f"u{self.user_id}_g{self.group_id}")

--- a/libzapi/infrastructure/api_clients/ticketing/__init__.py
+++ b/libzapi/infrastructure/api_clients/ticketing/__init__.py
@@ -5,6 +5,9 @@ from libzapi.infrastructure.api_clients.ticketing.brand_api_client import BrandA
 from libzapi.infrastructure.api_clients.ticketing.brand_agent_api_client import BrandAgentApiClient
 from libzapi.infrastructure.api_clients.ticketing.email_notification_api_client import EmailNotificationApiClient
 from libzapi.infrastructure.api_clients.ticketing.group_api_client import GroupApiClient
+from libzapi.infrastructure.api_clients.ticketing.group_membership_api_client import (
+    GroupMembershipApiClient,
+)
 from libzapi.infrastructure.api_clients.ticketing.macro_api_client import MacroApiClient
 from libzapi.infrastructure.api_clients.ticketing.organization_api_client import OrganizationApiClient
 from libzapi.infrastructure.api_clients.ticketing.request_api_client import RequestApiClient
@@ -36,6 +39,7 @@ __all__ = [
     "BrandAgentApiClient",
     "EmailNotificationApiClient",
     "GroupApiClient",
+    "GroupMembershipApiClient",
     "MacroApiClient",
     "OrganizationApiClient",
     "RequestApiClient",

--- a/libzapi/infrastructure/api_clients/ticketing/group_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/group_api_client.py
@@ -68,3 +68,7 @@ class GroupApiClient:
 
     def delete(self, group_id: int) -> None:
         self._http.delete(f"/api/v2/groups/{int(group_id)}")
+
+    def count_assignable(self) -> CountSnapshot:
+        data = self._http.get("/api/v2/groups/assignable/count")
+        return to_count_snapshot(data["count"])

--- a/libzapi/infrastructure/api_clients/ticketing/group_membership_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/group_membership_api_client.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+from libzapi.application.commands.ticketing.group_membership_cmds import (
+    CreateGroupMembershipCmd,
+)
+from libzapi.domain.models.ticketing.group_membership import GroupMembership
+from libzapi.domain.shared_objects.job_status import JobStatus
+from libzapi.infrastructure.http.client import HttpClient
+from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.mappers.ticketing.group_membership_mapper import (
+    to_payload_create,
+)
+from libzapi.infrastructure.serialization.parse import to_domain
+
+
+class GroupMembershipApiClient:
+    """HTTP adapter for Zendesk Group Memberships."""
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def list(self) -> Iterator[GroupMembership]:
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path="/api/v2/group_memberships",
+            base_url=self._http.base_url,
+            items_key="group_memberships",
+        ):
+            yield to_domain(data=obj, cls=GroupMembership)
+
+    def list_by_user(self, user_id: int) -> Iterator[GroupMembership]:
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path=f"/api/v2/users/{int(user_id)}/group_memberships",
+            base_url=self._http.base_url,
+            items_key="group_memberships",
+        ):
+            yield to_domain(data=obj, cls=GroupMembership)
+
+    def list_by_group(self, group_id: int) -> Iterator[GroupMembership]:
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path=f"/api/v2/groups/{int(group_id)}/memberships",
+            base_url=self._http.base_url,
+            items_key="group_memberships",
+        ):
+            yield to_domain(data=obj, cls=GroupMembership)
+
+    def list_assignable(self, group_id: int) -> Iterator[GroupMembership]:
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path=f"/api/v2/groups/{int(group_id)}/memberships/assignable",
+            base_url=self._http.base_url,
+            items_key="group_memberships",
+        ):
+            yield to_domain(data=obj, cls=GroupMembership)
+
+    def list_assignable_for_user(self, user_id: int) -> Iterator[GroupMembership]:
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path=f"/api/v2/users/{int(user_id)}/group_memberships/assignable",
+            base_url=self._http.base_url,
+            items_key="group_memberships",
+        ):
+            yield to_domain(data=obj, cls=GroupMembership)
+
+    def get(self, membership_id: int) -> GroupMembership:
+        data = self._http.get(f"/api/v2/group_memberships/{int(membership_id)}")
+        return to_domain(data=data["group_membership"], cls=GroupMembership)
+
+    def get_for_user(self, user_id: int, membership_id: int) -> GroupMembership:
+        data = self._http.get(
+            f"/api/v2/users/{int(user_id)}/group_memberships/{int(membership_id)}"
+        )
+        return to_domain(data=data["group_membership"], cls=GroupMembership)
+
+    def create(self, entity: CreateGroupMembershipCmd) -> GroupMembership:
+        payload = to_payload_create(entity)
+        data = self._http.post("/api/v2/group_memberships", payload)
+        return to_domain(data=data["group_membership"], cls=GroupMembership)
+
+    def create_for_user(
+        self, user_id: int, entity: CreateGroupMembershipCmd
+    ) -> GroupMembership:
+        payload = to_payload_create(entity)
+        data = self._http.post(
+            f"/api/v2/users/{int(user_id)}/group_memberships", payload
+        )
+        return to_domain(data=data["group_membership"], cls=GroupMembership)
+
+    def delete(self, membership_id: int) -> None:
+        self._http.delete(f"/api/v2/group_memberships/{int(membership_id)}")
+
+    def delete_for_user(self, user_id: int, membership_id: int) -> None:
+        self._http.delete(
+            f"/api/v2/users/{int(user_id)}/group_memberships/{int(membership_id)}"
+        )
+
+    def make_default(self, user_id: int, membership_id: int) -> list[GroupMembership]:
+        data = self._http.put(
+            f"/api/v2/users/{int(user_id)}/group_memberships/{int(membership_id)}/make_default",
+            {},
+        )
+        return [
+            to_domain(data=obj, cls=GroupMembership)
+            for obj in data.get("results", []) or []
+        ]
+
+    def create_many(
+        self, entities: Iterable[CreateGroupMembershipCmd]
+    ) -> JobStatus:
+        payload = {
+            "group_memberships": [to_payload_create(e)["group_membership"] for e in entities]
+        }
+        data = self._http.post("/api/v2/group_memberships/create_many", payload)
+        return to_domain(data=data["job_status"], cls=JobStatus)
+
+    def destroy_many(self, membership_ids: Iterable[int]) -> JobStatus:
+        ids_str = ",".join(str(int(i)) for i in membership_ids)
+        data = (
+            self._http.delete(
+                f"/api/v2/group_memberships/destroy_many?ids={ids_str}"
+            )
+            or {}
+        )
+        return to_domain(data=data["job_status"], cls=JobStatus)

--- a/libzapi/infrastructure/mappers/ticketing/group_membership_mapper.py
+++ b/libzapi/infrastructure/mappers/ticketing/group_membership_mapper.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from libzapi.application.commands.ticketing.group_membership_cmds import (
+    CreateGroupMembershipCmd,
+)
+
+
+def to_payload_create(cmd: CreateGroupMembershipCmd) -> dict:
+    body: dict = {"user_id": int(cmd.user_id), "group_id": int(cmd.group_id)}
+    if cmd.default is not None:
+        body["default"] = cmd.default
+    return {"group_membership": body}

--- a/tests/integration/ticketing/test_group_memberships.py
+++ b/tests/integration/ticketing/test_group_memberships.py
@@ -1,0 +1,107 @@
+import itertools
+import uuid
+
+import pytest
+
+from libzapi import Ticketing
+
+
+def _unique() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+def _first_agent(ticketing: Ticketing):
+    for u in itertools.islice(ticketing.users.list_all(), 200):
+        if getattr(u, "role", None) in {"agent", "admin"}:
+            return u
+    pytest.skip("No agent user available for group-membership tests.")
+
+
+def _fresh_group(ticketing: Ticketing):
+    return ticketing.groups.create(
+        name=f"libzapi gm {_unique()}",
+        description="created by libzapi integration test",
+    )
+
+
+def test_list_all(ticketing: Ticketing):
+    items = list(itertools.islice(ticketing.group_memberships.list_all(), 100))
+    assert isinstance(items, list)
+
+
+def test_list_by_user_and_group(ticketing: Ticketing):
+    agent = _first_agent(ticketing)
+    user_memberships = list(
+        itertools.islice(ticketing.group_memberships.list_by_user(agent.id), 50)
+    )
+    assert isinstance(user_memberships, list)
+    if user_memberships:
+        gid = user_memberships[0].group_id
+        group_memberships = list(
+            itertools.islice(
+                ticketing.group_memberships.list_by_group(gid), 50
+            )
+        )
+        assert isinstance(group_memberships, list)
+
+
+def test_list_assignable(ticketing: Ticketing):
+    groups = list(itertools.islice(ticketing.groups.list_assignable(), 5))
+    if not groups:
+        pytest.skip("No assignable groups available.")
+    items = list(
+        itertools.islice(
+            ticketing.group_memberships.list_assignable(groups[0].id), 50
+        )
+    )
+    assert isinstance(items, list)
+
+
+def test_create_delete(ticketing: Ticketing):
+    agent = _first_agent(ticketing)
+    group = _fresh_group(ticketing)
+    try:
+        membership = ticketing.group_memberships.create(
+            user_id=agent.id, group_id=group.id
+        )
+        assert membership.id > 0
+        assert membership.user_id == agent.id
+        assert membership.group_id == group.id
+        ticketing.group_memberships.delete(membership.id)
+    finally:
+        ticketing.groups.delete(group.id)
+
+
+def test_get_by_id_and_for_user(ticketing: Ticketing):
+    agent = _first_agent(ticketing)
+    group = _fresh_group(ticketing)
+    try:
+        membership = ticketing.group_memberships.create(
+            user_id=agent.id, group_id=group.id
+        )
+        fetched = ticketing.group_memberships.get_by_id(membership.id)
+        assert fetched.id == membership.id
+        fetched_for_user = ticketing.group_memberships.get_for_user(
+            agent.id, membership.id
+        )
+        assert fetched_for_user.id == membership.id
+        ticketing.group_memberships.delete(membership.id)
+    finally:
+        ticketing.groups.delete(group.id)
+
+
+def test_create_many_and_destroy_many(ticketing: Ticketing):
+    agent = _first_agent(ticketing)
+    g1 = _fresh_group(ticketing)
+    g2 = _fresh_group(ticketing)
+    try:
+        job = ticketing.group_memberships.create_many(
+            [
+                {"user_id": agent.id, "group_id": g1.id},
+                {"user_id": agent.id, "group_id": g2.id},
+            ]
+        )
+        assert job.id
+    finally:
+        ticketing.groups.delete(g1.id)
+        ticketing.groups.delete(g2.id)

--- a/tests/integration/ticketing/test_groups.py
+++ b/tests/integration/ticketing/test_groups.py
@@ -1,6 +1,5 @@
 import uuid
 
-from libzapi.application.commands.ticketing.group_cmds import CreateGroupCmd, UpdateGroupCmd
 from libzapi import Ticketing
 
 
@@ -19,24 +18,27 @@ def test_count_groups(ticketing: Ticketing):
     assert count_snapshot.value > 0, "Expected group count to be greater than zero"
 
 
+def test_count_assignable_groups(ticketing: Ticketing):
+    count_snapshot = ticketing.groups.count_assignable()
+    assert count_snapshot.value >= 0
+
+
 def test_create_update_delete_group(ticketing: Ticketing):
-    # Create a new group
     random_id = str(uuid.uuid4())
     new_group = ticketing.groups.create(
-        CreateGroupCmd(name=f"Test Group {random_id}", description="A group created for testing purposes")
+        name=f"Test Group {random_id}",
+        description="A group created for testing purposes",
     )
     assert new_group.id is not None, "Expected the created group to have an ID"
 
-    # Update the group
     updated_group = ticketing.groups.update(
         new_group.id,
-        UpdateGroupCmd(name=f"Updated Test Group {random_id}", description="An updated group for testing purposes"),
+        name=f"Updated Test Group {random_id}",
+        description="An updated group for testing purposes",
     )
-    assert updated_group.name == f"Updated Test Group {random_id}", "Expected the group name to be updated"
+    assert updated_group.name == f"Updated Test Group {random_id}"
 
-    # Get the group by ID
     fetched_group = ticketing.groups.get_by_id(new_group.id)
-    assert fetched_group.id == new_group.id, "Expected to fetch the same group by ID"
+    assert fetched_group.id == new_group.id
 
-    # Delete the group
     ticketing.groups.delete(new_group.id)

--- a/tests/unit/ticketing/test_group_membership.py
+++ b/tests/unit/ticketing/test_group_membership.py
@@ -1,0 +1,229 @@
+import pytest
+
+from libzapi.application.commands.ticketing.group_membership_cmds import (
+    CreateGroupMembershipCmd,
+)
+from libzapi.domain.errors import NotFound, RateLimited, Unauthorized, UnprocessableEntity
+from libzapi.infrastructure.api_clients.ticketing import GroupMembershipApiClient
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.group_membership_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Iterators
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "method, args, path",
+    [
+        ("list", [], "/api/v2/group_memberships"),
+        ("list_by_user", [42], "/api/v2/users/42/group_memberships"),
+        ("list_by_group", [7], "/api/v2/groups/7/memberships"),
+        ("list_assignable", [7], "/api/v2/groups/7/memberships/assignable"),
+        (
+            "list_assignable_for_user",
+            [42],
+            "/api/v2/users/42/group_memberships/assignable",
+        ),
+    ],
+)
+def test_list_endpoints_hit_expected_path(method, args, path, http, domain):
+    http.get.return_value = {"group_memberships": []}
+    client = GroupMembershipApiClient(http)
+    list(getattr(client, method)(*args))
+    http.get.assert_called_with(path)
+
+
+@pytest.mark.parametrize(
+    "method, args",
+    [
+        ("list", ()),
+        ("list_by_user", (42,)),
+        ("list_by_group", (7,)),
+        ("list_assignable", (7,)),
+        ("list_assignable_for_user", (42,)),
+    ],
+)
+def test_list_yields_items(method, args, http, domain):
+    http.get.return_value = {
+        "group_memberships": [{"id": 1}, {"id": 2}],
+        "meta": {"has_more": False},
+        "links": {"next": None},
+    }
+    client = GroupMembershipApiClient(http)
+    assert len(list(getattr(client, method)(*args))) == 2
+
+
+# ---------------------------------------------------------------------------
+# get / get_for_user
+# ---------------------------------------------------------------------------
+
+
+def test_get_calls_endpoint(http, domain):
+    http.get.return_value = {"group_membership": {"id": 5}}
+    client = GroupMembershipApiClient(http)
+    client.get(membership_id=5)
+    http.get.assert_called_with("/api/v2/group_memberships/5")
+
+
+def test_get_for_user_calls_endpoint(http, domain):
+    http.get.return_value = {"group_membership": {"id": 5}}
+    client = GroupMembershipApiClient(http)
+    client.get_for_user(user_id=3, membership_id=5)
+    http.get.assert_called_with("/api/v2/users/3/group_memberships/5")
+
+
+# ---------------------------------------------------------------------------
+# create / create_for_user
+# ---------------------------------------------------------------------------
+
+
+def test_create_posts_payload(http, domain):
+    http.post.return_value = {"group_membership": {"id": 1}}
+    client = GroupMembershipApiClient(http)
+    client.create(CreateGroupMembershipCmd(user_id=3, group_id=4))
+    http.post.assert_called_with(
+        "/api/v2/group_memberships",
+        {"group_membership": {"user_id": 3, "group_id": 4}},
+    )
+
+
+def test_create_for_user_posts_payload(http, domain):
+    http.post.return_value = {"group_membership": {"id": 1}}
+    client = GroupMembershipApiClient(http)
+    client.create_for_user(
+        user_id=3, entity=CreateGroupMembershipCmd(user_id=3, group_id=4, default=True)
+    )
+    http.post.assert_called_with(
+        "/api/v2/users/3/group_memberships",
+        {"group_membership": {"user_id": 3, "group_id": 4, "default": True}},
+    )
+
+
+# ---------------------------------------------------------------------------
+# delete variants
+# ---------------------------------------------------------------------------
+
+
+def test_delete_calls_endpoint(http):
+    client = GroupMembershipApiClient(http)
+    client.delete(membership_id=9)
+    http.delete.assert_called_with("/api/v2/group_memberships/9")
+
+
+def test_delete_for_user_calls_endpoint(http):
+    client = GroupMembershipApiClient(http)
+    client.delete_for_user(user_id=3, membership_id=9)
+    http.delete.assert_called_with("/api/v2/users/3/group_memberships/9")
+
+
+# ---------------------------------------------------------------------------
+# make_default
+# ---------------------------------------------------------------------------
+
+
+def test_make_default_puts_and_parses_results(http, domain):
+    http.put.return_value = {"results": [{"id": 1}, {"id": 2}]}
+    client = GroupMembershipApiClient(http)
+    result = client.make_default(user_id=3, membership_id=9)
+    http.put.assert_called_with(
+        "/api/v2/users/3/group_memberships/9/make_default", {}
+    )
+    assert len(result) == 2
+
+
+def test_make_default_with_null_results(http, domain):
+    http.put.return_value = {"results": None}
+    client = GroupMembershipApiClient(http)
+    assert client.make_default(user_id=3, membership_id=9) == []
+
+
+# ---------------------------------------------------------------------------
+# bulk
+# ---------------------------------------------------------------------------
+
+
+def test_create_many_posts_list(http, domain):
+    http.post.return_value = {"job_status": {"id": "abc"}}
+    client = GroupMembershipApiClient(http)
+    client.create_many(
+        [
+            CreateGroupMembershipCmd(user_id=1, group_id=2),
+            CreateGroupMembershipCmd(user_id=3, group_id=4, default=True),
+        ]
+    )
+    http.post.assert_called_with(
+        "/api/v2/group_memberships/create_many",
+        {
+            "group_memberships": [
+                {"user_id": 1, "group_id": 2},
+                {"user_id": 3, "group_id": 4, "default": True},
+            ]
+        },
+    )
+
+
+def test_destroy_many_builds_path(http, domain):
+    http.delete.return_value = {"job_status": {"id": "abc"}}
+    client = GroupMembershipApiClient(http)
+    client.destroy_many([1, 2, 3])
+    http.delete.assert_called_with(
+        "/api/v2/group_memberships/destroy_many?ids=1,2,3"
+    )
+
+
+def test_destroy_many_handles_none_response(http, domain):
+    http.delete.return_value = None
+    client = GroupMembershipApiClient(http)
+    with pytest.raises(KeyError):
+        client.destroy_many([1])
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+)
+def test_raises_on_http_error(error_cls, http):
+    http.get.side_effect = error_cls("error")
+    client = GroupMembershipApiClient(http)
+    with pytest.raises(error_cls):
+        list(client.list())
+
+
+# ---------------------------------------------------------------------------
+# Domain logical key
+# ---------------------------------------------------------------------------
+
+
+def test_group_membership_logical_key():
+    from datetime import datetime
+
+    from libzapi.domain.models.ticketing.group_membership import GroupMembership
+
+    gm = GroupMembership(
+        id=1,
+        user_id=42,
+        group_id=7,
+        default=True,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    assert gm.logical_key.as_str() == "group_membership:u42_g7"

--- a/tests/unit/ticketing/test_group_membership_mapper.py
+++ b/tests/unit/ticketing/test_group_membership_mapper.py
@@ -1,0 +1,36 @@
+from libzapi.application.commands.ticketing.group_membership_cmds import (
+    CreateGroupMembershipCmd,
+)
+from libzapi.infrastructure.mappers.ticketing.group_membership_mapper import (
+    to_payload_create,
+)
+
+
+def test_create_minimum_payload():
+    payload = to_payload_create(CreateGroupMembershipCmd(user_id=1, group_id=2))
+    assert payload == {"group_membership": {"user_id": 1, "group_id": 2}}
+
+
+def test_create_with_default_flag():
+    payload = to_payload_create(
+        CreateGroupMembershipCmd(user_id=1, group_id=2, default=True)
+    )
+    assert payload == {
+        "group_membership": {"user_id": 1, "group_id": 2, "default": True}
+    }
+
+
+def test_create_omits_default_when_none():
+    payload = to_payload_create(
+        CreateGroupMembershipCmd(user_id=1, group_id=2, default=None)
+    )
+    assert "default" not in payload["group_membership"]
+
+
+def test_create_coerces_ids_to_int():
+    payload = to_payload_create(
+        CreateGroupMembershipCmd(user_id="1", group_id="2")  # type: ignore[arg-type]
+    )
+    body = payload["group_membership"]
+    assert isinstance(body["user_id"], int)
+    assert isinstance(body["group_id"], int)

--- a/tests/unit/ticketing/test_group_memberships_service.py
+++ b/tests/unit/ticketing/test_group_memberships_service.py
@@ -1,0 +1,139 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.commands.ticketing.group_membership_cmds import (
+    CreateGroupMembershipCmd,
+)
+from libzapi.application.services.ticketing.group_memberships_service import (
+    GroupMembershipsService,
+)
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return GroupMembershipsService(client), client
+
+
+class TestDelegation:
+    @pytest.mark.parametrize(
+        "method, args, client_method, client_args",
+        [
+            ("list_all", (), "list", ()),
+            ("list_by_user", (42,), "list_by_user", (42,)),
+            ("list_by_group", (7,), "list_by_group", (7,)),
+            ("list_assignable", (7,), "list_assignable", (7,)),
+            (
+                "list_assignable_for_user",
+                (42,),
+                "list_assignable_for_user",
+                (42,),
+            ),
+            ("get_by_id", (5,), "get", (5,)),
+            ("get_for_user", (3, 5), "get_for_user", (3, 5)),
+            ("make_default", (3, 9), "make_default", (3, 9)),
+        ],
+    )
+    def test_method_delegates(self, method, args, client_method, client_args):
+        service, client = _make_service()
+        getattr(client, client_method).return_value = sentinel.result
+
+        result = getattr(service, method)(*args)
+
+        getattr(client, client_method).assert_called_once_with(*client_args)
+        assert result is sentinel.result
+
+    def test_delete_delegates(self):
+        service, client = _make_service()
+        service.delete(9)
+        client.delete.assert_called_once_with(9)
+
+    def test_delete_for_user_delegates(self):
+        service, client = _make_service()
+        service.delete_for_user(3, 9)
+        client.delete_for_user.assert_called_once_with(3, 9)
+
+
+class TestCreate:
+    def test_builds_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.create.return_value = sentinel.gm
+
+        result = service.create(user_id=3, group_id=4, default=True)
+
+        cmd = client.create.call_args.kwargs["entity"]
+        assert isinstance(cmd, CreateGroupMembershipCmd)
+        assert cmd.user_id == 3
+        assert cmd.group_id == 4
+        assert cmd.default is True
+        assert result is sentinel.gm
+
+    def test_default_omitted_builds_cmd_with_none(self):
+        service, client = _make_service()
+        service.create(user_id=3, group_id=4)
+        cmd = client.create.call_args.kwargs["entity"]
+        assert cmd.default is None
+
+
+class TestCreateForUser:
+    def test_builds_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.create_for_user.return_value = sentinel.gm
+
+        result = service.create_for_user(user_id=3, group_id=4)
+
+        call = client.create_for_user.call_args
+        assert call.kwargs["user_id"] == 3
+        cmd = call.kwargs["entity"]
+        assert isinstance(cmd, CreateGroupMembershipCmd)
+        assert cmd.user_id == 3
+        assert cmd.group_id == 4
+        assert result is sentinel.gm
+
+
+class TestCreateMany:
+    def test_converts_dicts_to_commands(self):
+        service, client = _make_service()
+        client.create_many.return_value = sentinel.job
+
+        result = service.create_many(
+            [
+                {"user_id": 1, "group_id": 2},
+                {"user_id": 3, "group_id": 4, "default": True},
+            ]
+        )
+
+        entities = client.create_many.call_args.kwargs["entities"]
+        assert all(isinstance(c, CreateGroupMembershipCmd) for c in entities)
+        assert entities[0].user_id == 1
+        assert entities[1].default is True
+        assert result is sentinel.job
+
+    def test_empty_input(self):
+        service, client = _make_service()
+        service.create_many([])
+        assert client.create_many.call_args.kwargs["entities"] == []
+
+
+class TestDestroyMany:
+    def test_delegates(self):
+        service, client = _make_service()
+        client.destroy_many.return_value = sentinel.job
+        assert service.destroy_many([1, 2]) is sentinel.job
+        client.destroy_many.assert_called_once_with(membership_ids=[1, 2])
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.list.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list_all()
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_create_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.create.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.create(user_id=1, group_id=2)

--- a/tests/unit/ticketing/test_groups.py
+++ b/tests/unit/ticketing/test_groups.py
@@ -1,8 +1,26 @@
 from datetime import datetime
+from unittest.mock import Mock, sentinel
 
+import pytest
+
+from libzapi.application.commands.ticketing.group_cmds import (
+    CreateGroupCmd,
+    UpdateGroupCmd,
+)
+from libzapi.application.services.ticketing.groups_service import GroupsService
+from libzapi.domain.errors import NotFound, Unauthorized
 from libzapi.domain.models.ticketing.group import Group
-from libzapi.infrastructure.mappers.ticketing.group_mapper import to_payload_create
+from libzapi.infrastructure.api_clients.ticketing import GroupApiClient
+from libzapi.infrastructure.mappers.ticketing.group_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
 from libzapi.infrastructure.serialization.parse import to_domain
+
+
+# ---------------------------------------------------------------------------
+# Domain / mapper
+# ---------------------------------------------------------------------------
 
 
 def test_mapper_to_domain_and_back_payload_roundtrip():
@@ -47,3 +65,247 @@ def test_group_logical_key():
         deleted=False,
     )
     assert group.logical_key.as_str() == "group:engineering"
+
+
+# ---------------------------------------------------------------------------
+# Mapper: to_payload_update branches
+# ---------------------------------------------------------------------------
+
+
+def test_update_payload_empty_cmd():
+    assert to_payload_update(UpdateGroupCmd()) == {"group": {}}
+
+
+def test_update_payload_all_fields():
+    cmd = UpdateGroupCmd(name="n", description="d", is_public=True, default=False)
+    assert to_payload_update(cmd) == {
+        "group": {
+            "name": "n",
+            "description": "d",
+            "is_public": True,
+            "default": False,
+        }
+    }
+
+
+def test_update_payload_preserves_false_booleans():
+    cmd = UpdateGroupCmd(is_public=False, default=False)
+    assert to_payload_update(cmd) == {
+        "group": {"is_public": False, "default": False}
+    }
+
+
+# ---------------------------------------------------------------------------
+# API client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.group_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+@pytest.mark.parametrize(
+    "method, args, path",
+    [
+        ("list", (), "/api/v2/groups"),
+        ("list_user", (42,), "/api/v2/users/42/groups"),
+        ("list_assignable", (), "/api/v2/groups/assignable"),
+    ],
+)
+def test_list_endpoints(method, args, path, http, domain):
+    http.get.return_value = {"groups": []}
+    client = GroupApiClient(http)
+    list(getattr(client, method)(*args))
+    http.get.assert_called_with(path)
+
+
+@pytest.mark.parametrize(
+    "method, args",
+    [
+        ("list", ()),
+        ("list_user", (42,)),
+        ("list_assignable", ()),
+    ],
+)
+def test_list_yields_items(method, args, http, domain):
+    http.get.return_value = {
+        "groups": [{"id": 1}, {"id": 2}],
+        "meta": {"has_more": False},
+        "links": {"next": None},
+    }
+    client = GroupApiClient(http)
+    assert len(list(getattr(client, method)(*args))) == 2
+
+
+def test_count_hits_endpoint(http):
+    http.get.return_value = {
+        "count": {"refreshed_at": "2024-01-01T00:00:00Z", "value": 3}
+    }
+    client = GroupApiClient(http)
+    assert client.count().value == 3
+    http.get.assert_called_with("/api/v2/groups/count")
+
+
+def test_count_user_hits_endpoint(http):
+    http.get.return_value = {
+        "count": {"refreshed_at": "2024-01-01T00:00:00Z", "value": 2}
+    }
+    client = GroupApiClient(http)
+    assert client.count_user(user_id=42).value == 2
+    http.get.assert_called_with("/api/v2/users/42/groups/count")
+
+
+def test_get_hits_endpoint(http, domain):
+    http.get.return_value = {"group": {"id": 5}}
+    client = GroupApiClient(http)
+    client.get(group_id=5)
+    http.get.assert_called_with("/api/v2/groups/5")
+
+
+def test_count_assignable_hits_endpoint(http):
+    http.get.return_value = {
+        "count": {"refreshed_at": "2024-01-01T00:00:00Z", "value": 7}
+    }
+    client = GroupApiClient(http)
+    snapshot = client.count_assignable()
+    http.get.assert_called_with("/api/v2/groups/assignable/count")
+    assert snapshot.value == 7
+
+
+def test_create_posts_payload(http, domain):
+    http.post.return_value = {"group": {"id": 1}}
+    client = GroupApiClient(http)
+    client.create(CreateGroupCmd(name="Acme"))
+    http.post.assert_called_with(
+        "/api/v2/groups",
+        {
+            "group": {
+                "name": "Acme",
+                "description": "",
+                "is_public": False,
+                "default": False,
+            }
+        },
+    )
+
+
+def test_update_puts_payload(http, domain):
+    http.put.return_value = {"group": {"id": 1}}
+    client = GroupApiClient(http)
+    client.update(group_id=1, entity=UpdateGroupCmd(name="x"))
+    http.put.assert_called_with("/api/v2/groups/1", {"group": {"name": "x"}})
+
+
+def test_delete_calls_endpoint(http):
+    client = GroupApiClient(http)
+    client.delete(group_id=5)
+    http.delete.assert_called_with("/api/v2/groups/5")
+
+
+# ---------------------------------------------------------------------------
+# GroupsService
+# ---------------------------------------------------------------------------
+
+
+def _make_service():
+    client = Mock()
+    return GroupsService(client), client
+
+
+class TestServiceDelegation:
+    @pytest.mark.parametrize(
+        "method, args, client_method, client_args",
+        [
+            ("list_all", (), "list", ()),
+            ("list_user", (42,), "list_user", (42,)),
+            ("list_assignable", (), "list_assignable", ()),
+            ("count", (), "count", ()),
+            ("count_user", (42,), "count_user", (42,)),
+            ("count_assignable", (), "count_assignable", ()),
+            ("get_by_id", (5,), "get", (5,)),
+        ],
+    )
+    def test_delegates(self, method, args, client_method, client_args):
+        service, client = _make_service()
+        getattr(client, client_method).return_value = sentinel.result
+        result = getattr(service, method)(*args)
+        getattr(client, client_method).assert_called_once_with(*client_args)
+        assert result is sentinel.result
+
+    def test_delete_delegates(self):
+        service, client = _make_service()
+        service.delete(5)
+        client.delete.assert_called_once_with(5)
+
+
+class TestServiceCreate:
+    def test_builds_cmd_with_kwargs(self):
+        service, client = _make_service()
+        client.create.return_value = sentinel.group
+
+        result = service.create(name="Acme", description="desc", is_public=True)
+
+        cmd = client.create.call_args.kwargs["entity"]
+        assert isinstance(cmd, CreateGroupCmd)
+        assert cmd.name == "Acme"
+        assert cmd.description == "desc"
+        assert cmd.is_public is True
+        assert cmd.default is False
+        assert result is sentinel.group
+
+    def test_uses_defaults_when_only_name(self):
+        service, client = _make_service()
+        service.create(name="Acme")
+        cmd = client.create.call_args.kwargs["entity"]
+        assert cmd.description == ""
+        assert cmd.is_public is False
+        assert cmd.default is False
+
+
+class TestServiceUpdate:
+    def test_builds_cmd_with_kwargs(self):
+        service, client = _make_service()
+        client.update.return_value = sentinel.group
+
+        result = service.update(7, name="New", description="d")
+
+        call = client.update.call_args
+        assert call.kwargs["group_id"] == 7
+        cmd = call.kwargs["entity"]
+        assert isinstance(cmd, UpdateGroupCmd)
+        assert cmd.name == "New"
+        assert cmd.description == "d"
+        assert result is sentinel.group
+
+    def test_empty_kwargs_yields_blank_cmd(self):
+        service, client = _make_service()
+        service.update(7)
+        cmd = client.update.call_args.kwargs["entity"]
+        assert cmd.name is None
+
+
+class TestServiceErrors:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_all_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.list.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list_all()
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_create_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.create.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.create(name="x")


### PR DESCRIPTION
## Summary
- **New Group Memberships resource**: full surface — `list`, `list_by_user/group`, `list_assignable`, `list_assignable_for_user`, `get` / `get_for_user`, `create` / `create_for_user`, `delete` / `delete_for_user`, `make_default`, `create_many`, `destroy_many`. Exposed on the `Ticketing` facade as `ticketing.group_memberships`.
- **Groups**: adds `count_assignable`; migrates `create`/`update` to the `**fields` kwargs pattern used by organizations/users/tickets.
- Tracking: part of #79 (Batch 1 — Groups + memberships).

## Test plan
- [x] Unit: `test_groups.py`, `test_group_membership.py`, `test_group_membership_mapper.py`, `test_group_memberships_service.py` — 84 tests, **100% coverage** on all 10 new/touched modules (domain, cmds, mappers, api clients, services).
- [x] Full unit suite green (`pytest tests/unit` — 1770 passed).
- [ ] Integration: `test_group_memberships.py` (6 live tests covering list endpoints, create/delete, get variants, create_many).
- [ ] Integration: updated `test_groups.py` to exercise the new kwargs signature + `count_assignable`.

## Breaking change
`GroupsService.create(entity=...)` / `update(group_id, entity=...)` → `create(**fields)` / `update(group_id, **fields)`. Matches the pattern established by PRs #77 / #78 / #80. The existing integration test is migrated in this PR; no other callers were found in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)