### PR TITLE
feat(ticketing): add brands CUD and check_host_mapping

### DIFF
--- a/libzapi/application/commands/ticketing/brand_cmds.py
+++ b/libzapi/application/commands/ticketing/brand_cmds.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, TypeAlias
+
+
+@dataclass(frozen=True, slots=True)
+class CreateBrandCmd:
+    name: str
+    subdomain: str
+    active: bool | None = None
+    host_mapping: str | None = None
+    signature_template: str | None = None
+    ticket_form_ids: Iterable[int] | None = None
+    brand_url: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateBrandCmd:
+    name: str | None = None
+    subdomain: str | None = None
+    active: bool | None = None
+    host_mapping: str | None = None
+    signature_template: str | None = None
+    ticket_form_ids: Iterable[int] | None = None
+    brand_url: str | None = None
+    default: bool | None = None
+
+
+BrandCmd: TypeAlias = CreateBrandCmd | UpdateBrandCmd

--- a/libzapi/application/services/ticketing/brands_service.py
+++ b/libzapi/application/services/ticketing/brands_service.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
 from typing import Iterable
 
+from libzapi.application.commands.ticketing.brand_cmds import (
+    CreateBrandCmd,
+    UpdateBrandCmd,
+)
 from libzapi.domain.models.ticketing.brand import Brand
 from libzapi.infrastructure.api_clients.ticketing import BrandApiClient
 
@@ -15,3 +21,19 @@ class BrandsService:
 
     def get(self, brand_id: int) -> Brand:
         return self._client.get(brand_id=brand_id)
+
+    def create(self, **fields) -> Brand:
+        return self._client.create(entity=CreateBrandCmd(**fields))
+
+    def update(self, brand_id: int, **fields) -> Brand:
+        return self._client.update(
+            brand_id=brand_id, entity=UpdateBrandCmd(**fields)
+        )
+
+    def delete(self, brand_id: int) -> None:
+        self._client.delete(brand_id=brand_id)
+
+    def check_host_mapping(self, host_mapping: str, subdomain: str) -> dict:
+        return self._client.check_host_mapping(
+            host_mapping=host_mapping, subdomain=subdomain
+        )

--- a/libzapi/domain/models/ticketing/brand.py
+++ b/libzapi/domain/models/ticketing/brand.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List
+from typing import List, Optional
 
 from libzapi.domain.shared_objects.logical_key import LogicalKey
 from libzapi.domain.shared_objects.thumbnail import Thumbnail
@@ -28,17 +28,18 @@ class Brand:
     url: str
     name: str
     subdomain: str
-    host_mapping: str | None
+    host_mapping: Optional[str]
     has_help_center: bool
     help_center_state: str
     active: bool
     default: bool
     is_deleted: bool
-    logo: Logo
     ticket_form_ids: List[int]
     signature_template: str
     created_at: datetime
     updated_at: datetime
+    logo: Optional[Logo] = None
+    brand_url: Optional[str] = None
 
     @property
     def logical_key(self) -> LogicalKey:

--- a/libzapi/infrastructure/api_clients/ticketing/brand_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/brand_api_client.py
@@ -2,9 +2,17 @@ from __future__ import annotations
 
 from typing import Iterator
 
+from libzapi.application.commands.ticketing.brand_cmds import (
+    CreateBrandCmd,
+    UpdateBrandCmd,
+)
 from libzapi.domain.models.ticketing.brand import Brand
 from libzapi.infrastructure.http.client import HttpClient
 from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.mappers.ticketing.brand_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
 from libzapi.infrastructure.serialization.parse import to_domain
 
 
@@ -26,3 +34,21 @@ class BrandApiClient:
     def get(self, brand_id: int) -> Brand:
         data = self._http.get(f"/api/v2/brands/{int(brand_id)}")
         return to_domain(data=data["brand"], cls=Brand)
+
+    def create(self, entity: CreateBrandCmd) -> Brand:
+        payload = to_payload_create(entity)
+        data = self._http.post("/api/v2/brands", payload)
+        return to_domain(data=data["brand"], cls=Brand)
+
+    def update(self, brand_id: int, entity: UpdateBrandCmd) -> Brand:
+        payload = to_payload_update(entity)
+        data = self._http.put(f"/api/v2/brands/{int(brand_id)}", payload)
+        return to_domain(data=data["brand"], cls=Brand)
+
+    def delete(self, brand_id: int) -> None:
+        self._http.delete(f"/api/v2/brands/{int(brand_id)}")
+
+    def check_host_mapping(self, host_mapping: str, subdomain: str) -> dict:
+        return self._http.get(
+            f"/api/v2/brands/check_host_mapping?host_mapping={host_mapping}&subdomain={subdomain}"
+        )

--- a/libzapi/infrastructure/mappers/ticketing/brand_mapper.py
+++ b/libzapi/infrastructure/mappers/ticketing/brand_mapper.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from libzapi.application.commands.ticketing.brand_cmds import (
+    CreateBrandCmd,
+    UpdateBrandCmd,
+)
+
+
+_OPTIONAL_FIELDS = (
+    "active",
+    "host_mapping",
+    "signature_template",
+    "brand_url",
+)
+
+
+def to_payload_create(cmd: CreateBrandCmd) -> dict:
+    body: dict = {"name": cmd.name, "subdomain": cmd.subdomain}
+    for field in _OPTIONAL_FIELDS:
+        value = getattr(cmd, field)
+        if value is not None:
+            body[field] = value
+    if cmd.ticket_form_ids is not None:
+        body["ticket_form_ids"] = list(cmd.ticket_form_ids)
+    return {"brand": body}
+
+
+def to_payload_update(cmd: UpdateBrandCmd) -> dict:
+    body: dict = {}
+    if cmd.name is not None:
+        body["name"] = cmd.name
+    if cmd.subdomain is not None:
+        body["subdomain"] = cmd.subdomain
+    for field in _OPTIONAL_FIELDS:
+        value = getattr(cmd, field)
+        if value is not None:
+            body[field] = value
+    if cmd.ticket_form_ids is not None:
+        body["ticket_form_ids"] = list(cmd.ticket_form_ids)
+    if cmd.default is not None:
+        body["default"] = cmd.default
+    return {"brand": body}

--- a/tests/integration/ticketing/test_brand.py
+++ b/tests/integration/ticketing/test_brand.py
@@ -1,0 +1,49 @@
+import itertools
+import uuid
+
+import pytest
+
+from libzapi import Ticketing
+
+
+def _unique() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+def _create_brand(ticketing: Ticketing, **overrides):
+    suffix = _unique()
+    defaults = dict(
+        name=f"libzapi brand {suffix}",
+        subdomain=f"libzapi-{suffix}",
+    )
+    defaults.update(overrides)
+    return ticketing.brands.create(**defaults)
+
+
+def test_list_and_get(ticketing: Ticketing):
+    brands = list(itertools.islice(ticketing.brands.list(), 50))
+    assert len(brands) > 0
+    brand = ticketing.brands.get(brands[0].id)
+    assert brand.id == brands[0].id
+
+
+def test_create_update_delete(ticketing: Ticketing):
+    try:
+        brand = _create_brand(ticketing, signature_template="hello")
+    except Exception as e:
+        pytest.skip(f"Cannot create brand on this tenant: {e}")
+    try:
+        assert brand.id > 0
+        updated = ticketing.brands.update(
+            brand.id, signature_template="updated by libzapi"
+        )
+        assert updated.signature_template == "updated by libzapi"
+    finally:
+        ticketing.brands.delete(brand.id)
+
+
+def test_check_host_mapping(ticketing: Ticketing):
+    result = ticketing.brands.check_host_mapping(
+        host_mapping=f"help-{_unique()}.invalid.example", subdomain=f"libzapi-{_unique()}"
+    )
+    assert isinstance(result, dict)

--- a/tests/unit/ticketing/test_brand.py
+++ b/tests/unit/ticketing/test_brand.py
@@ -1,7 +1,15 @@
+import pytest
 from hypothesis import given
 from hypothesis.strategies import just, builds
 
+from libzapi.application.commands.ticketing.brand_cmds import (
+    CreateBrandCmd,
+    UpdateBrandCmd,
+)
+from libzapi.domain.errors import NotFound, RateLimited, Unauthorized, UnprocessableEntity
 from libzapi.domain.models.ticketing.brand import Brand
+from libzapi.infrastructure.api_clients.ticketing import BrandApiClient
+
 
 strategy = builds(
     Brand,
@@ -10,5 +18,108 @@ strategy = builds(
 
 
 @given(strategy)
-def test_session_logical_key_from_id(model: Brand):
+def test_brand_logical_key_from_name(model: Brand):
     assert model.logical_key.as_str() == "brand:acme"
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.brand_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+# ---------------------------------------------------------------------------
+# list / get
+# ---------------------------------------------------------------------------
+
+
+def test_list_endpoint(http, domain):
+    http.get.return_value = {"brands": []}
+    client = BrandApiClient(http)
+    list(client.list())
+    http.get.assert_called_with("/api/v2/brands")
+
+
+def test_list_yields_items(http, domain):
+    http.get.return_value = {
+        "brands": [{"id": 1}, {"id": 2}],
+        "meta": {"has_more": False},
+        "links": {"next": None},
+    }
+    client = BrandApiClient(http)
+    assert len(list(client.list())) == 2
+
+
+def test_get_endpoint(http, domain):
+    http.get.return_value = {"brand": {"id": 5}}
+    client = BrandApiClient(http)
+    client.get(brand_id=5)
+    http.get.assert_called_with("/api/v2/brands/5")
+
+
+# ---------------------------------------------------------------------------
+# create / update / delete
+# ---------------------------------------------------------------------------
+
+
+def test_create_posts_payload(http, domain):
+    http.post.return_value = {"brand": {"id": 1}}
+    client = BrandApiClient(http)
+    client.create(CreateBrandCmd(name="Acme", subdomain="acme"))
+    http.post.assert_called_with(
+        "/api/v2/brands", {"brand": {"name": "Acme", "subdomain": "acme"}}
+    )
+
+
+def test_update_puts_payload(http, domain):
+    http.put.return_value = {"brand": {"id": 1}}
+    client = BrandApiClient(http)
+    client.update(brand_id=5, entity=UpdateBrandCmd(signature_template="sig"))
+    http.put.assert_called_with(
+        "/api/v2/brands/5", {"brand": {"signature_template": "sig"}}
+    )
+
+
+def test_delete_calls_endpoint(http):
+    client = BrandApiClient(http)
+    client.delete(brand_id=9)
+    http.delete.assert_called_with("/api/v2/brands/9")
+
+
+# ---------------------------------------------------------------------------
+# check_host_mapping
+# ---------------------------------------------------------------------------
+
+
+def test_check_host_mapping_calls_endpoint(http):
+    http.get.return_value = {"ok": True}
+    client = BrandApiClient(http)
+    result = client.check_host_mapping(host_mapping="help.x.com", subdomain="x")
+    http.get.assert_called_with(
+        "/api/v2/brands/check_host_mapping?host_mapping=help.x.com&subdomain=x"
+    )
+    assert result == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+)
+def test_raises_on_http_error(error_cls, http):
+    http.get.side_effect = error_cls("error")
+    client = BrandApiClient(http)
+    with pytest.raises(error_cls):
+        list(client.list())

--- a/tests/unit/ticketing/test_brand_mapper.py
+++ b/tests/unit/ticketing/test_brand_mapper.py
@@ -1,0 +1,80 @@
+from libzapi.application.commands.ticketing.brand_cmds import (
+    CreateBrandCmd,
+    UpdateBrandCmd,
+)
+from libzapi.infrastructure.mappers.ticketing.brand_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
+
+
+def test_create_minimal_payload():
+    payload = to_payload_create(CreateBrandCmd(name="Acme", subdomain="acme"))
+    assert payload == {"brand": {"name": "Acme", "subdomain": "acme"}}
+
+
+def test_create_with_all_optional_fields():
+    cmd = CreateBrandCmd(
+        name="Acme",
+        subdomain="acme",
+        active=True,
+        host_mapping="help.acme.com",
+        signature_template="sig",
+        ticket_form_ids=[1, 2],
+        brand_url="https://acme.com",
+    )
+    body = to_payload_create(cmd)["brand"]
+    assert body == {
+        "name": "Acme",
+        "subdomain": "acme",
+        "active": True,
+        "host_mapping": "help.acme.com",
+        "signature_template": "sig",
+        "brand_url": "https://acme.com",
+        "ticket_form_ids": [1, 2],
+    }
+
+
+def test_create_converts_iterable_to_list():
+    cmd = CreateBrandCmd(name="Acme", subdomain="acme", ticket_form_ids=iter([1, 2]))
+    body = to_payload_create(cmd)["brand"]
+    assert body["ticket_form_ids"] == [1, 2]
+
+
+def test_create_preserves_false_active():
+    cmd = CreateBrandCmd(name="Acme", subdomain="acme", active=False)
+    assert to_payload_create(cmd)["brand"]["active"] is False
+
+
+def test_update_empty_cmd_returns_empty_patch():
+    assert to_payload_update(UpdateBrandCmd()) == {"brand": {}}
+
+
+def test_update_all_fields():
+    cmd = UpdateBrandCmd(
+        name="Acme",
+        subdomain="acme",
+        active=False,
+        host_mapping="h",
+        signature_template="s",
+        ticket_form_ids=[9],
+        brand_url="u",
+        default=True,
+    )
+    assert to_payload_update(cmd) == {
+        "brand": {
+            "name": "Acme",
+            "subdomain": "acme",
+            "active": False,
+            "host_mapping": "h",
+            "signature_template": "s",
+            "brand_url": "u",
+            "ticket_form_ids": [9],
+            "default": True,
+        }
+    }
+
+
+def test_update_preserves_false_default():
+    body = to_payload_update(UpdateBrandCmd(default=False))["brand"]
+    assert body["default"] is False

--- a/tests/unit/ticketing/test_brands_service.py
+++ b/tests/unit/ticketing/test_brands_service.py
@@ -1,0 +1,93 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.commands.ticketing.brand_cmds import (
+    CreateBrandCmd,
+    UpdateBrandCmd,
+)
+from libzapi.application.services.ticketing.brands_service import BrandsService
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service():
+    client = Mock()
+    return BrandsService(client), client
+
+
+class TestDelegation:
+    def test_list_delegates(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.brands
+        assert service.list() is sentinel.brands
+
+    def test_get_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.brand
+        assert service.get(5) is sentinel.brand
+        client.get.assert_called_once_with(brand_id=5)
+
+    def test_delete_delegates(self):
+        service, client = _make_service()
+        service.delete(5)
+        client.delete.assert_called_once_with(brand_id=5)
+
+    def test_check_host_mapping_delegates(self):
+        service, client = _make_service()
+        client.check_host_mapping.return_value = {"ok": True}
+        assert service.check_host_mapping("h", "s") == {"ok": True}
+        client.check_host_mapping.assert_called_once_with(
+            host_mapping="h", subdomain="s"
+        )
+
+
+class TestCreate:
+    def test_builds_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.create.return_value = sentinel.brand
+
+        result = service.create(name="Acme", subdomain="acme", signature_template="sig")
+
+        cmd = client.create.call_args.kwargs["entity"]
+        assert isinstance(cmd, CreateBrandCmd)
+        assert cmd.name == "Acme"
+        assert cmd.subdomain == "acme"
+        assert cmd.signature_template == "sig"
+        assert result is sentinel.brand
+
+
+class TestUpdate:
+    def test_builds_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.update.return_value = sentinel.brand
+
+        result = service.update(7, signature_template="updated")
+
+        call = client.update.call_args
+        assert call.kwargs["brand_id"] == 7
+        cmd = call.kwargs["entity"]
+        assert isinstance(cmd, UpdateBrandCmd)
+        assert cmd.signature_template == "updated"
+        assert result is sentinel.brand
+
+    def test_empty_kwargs_yields_blank_cmd(self):
+        service, client = _make_service()
+        service.update(7)
+        cmd = client.update.call_args.kwargs["entity"]
+        assert cmd.name is None
+        assert cmd.subdomain is None
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.list.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list()
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_create_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.create.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.create(name="A", subdomain="a")


### PR DESCRIPTION
## Summary
- **Brands CUD**: create, update, delete, and `check_host_mapping` via the Zendesk Brands API.
- `CreateBrandCmd` / `UpdateBrandCmd` dataclasses + mapper following the org/user/group pattern.
- `BrandsService`: `**fields` kwargs on create/update.
- Domain: relax `logo` to `Optional[Logo]` and add optional `brand_url` — freshly-created brands return `logo: null` until a logo is uploaded, which previously broke deserialization.
- Tracking: part of #79 (Batch 1).

## Test plan
- [x] Unit: `test_brand.py`, `test_brand_mapper.py`, `test_brands_service.py` — 30 tests, **100% coverage** on cmds, mapper, api client, service, domain.
- [x] Full unit suite green (`pytest tests/unit` — 1717 passed).
- [ ] Integration: `test_brand.py` — list/get, create-update-delete, host-mapping check (skipped on tenants where brand creation is locked down).

## Breaking change
`BrandsService.get(brand_id)` already used the `brand_id=` kwarg so is unchanged. No other external callers were found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)