### PR TITLE
feat(ticketing): add sla policies CUD, reorder, definitions

### DIFF
--- a/libzapi/application/commands/ticketing/sla_policy_cmds.py
+++ b/libzapi/application/commands/ticketing/sla_policy_cmds.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, TypeAlias
+
+
+@dataclass(frozen=True, slots=True)
+class CreateSlaPolicyCmd:
+    title: str
+    filter: dict[str, Any]
+    policy_metrics: Iterable[dict[str, Any]]
+    description: str | None = None
+    position: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateSlaPolicyCmd:
+    title: str | None = None
+    filter: dict[str, Any] | None = None
+    policy_metrics: Iterable[dict[str, Any]] | None = None
+    description: str | None = None
+    position: int | None = None
+
+
+SlaPolicyCmd: TypeAlias = CreateSlaPolicyCmd | UpdateSlaPolicyCmd

--- a/libzapi/application/services/ticketing/sla_policies_service.py
+++ b/libzapi/application/services/ticketing/sla_policies_service.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
 from typing import Iterable
 
+from libzapi.application.commands.ticketing.sla_policy_cmds import (
+    CreateSlaPolicyCmd,
+    UpdateSlaPolicyCmd,
+)
 from libzapi.domain.models.ticketing.sla_policies import SlaPolicy
 from libzapi.infrastructure.api_clients.ticketing.sla_policy_api_client import SlaPolicyApiClient
 
@@ -13,5 +19,22 @@ class SlaPoliciesService:
     def list(self) -> Iterable[SlaPolicy]:
         return self._client.list()
 
+    def list_definitions(self) -> dict:
+        return self._client.list_definitions()
+
     def get(self, sla_policy_id: int) -> SlaPolicy:
         return self._client.get(sla_policy_id=sla_policy_id)
+
+    def create(self, **fields) -> SlaPolicy:
+        return self._client.create(entity=CreateSlaPolicyCmd(**fields))
+
+    def update(self, sla_policy_id: int, **fields) -> SlaPolicy:
+        return self._client.update(
+            sla_policy_id=sla_policy_id, entity=UpdateSlaPolicyCmd(**fields)
+        )
+
+    def delete(self, sla_policy_id: int) -> None:
+        self._client.delete(sla_policy_id=sla_policy_id)
+
+    def reorder(self, sla_policy_ids: Iterable[int]) -> list[SlaPolicy]:
+        return self._client.reorder(sla_policy_ids=sla_policy_ids)

--- a/libzapi/infrastructure/api_clients/ticketing/sla_policy_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/sla_policy_api_client.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
-from typing import Iterator
+from typing import Iterable, Iterator
 
+from libzapi.application.commands.ticketing.sla_policy_cmds import (
+    CreateSlaPolicyCmd,
+    UpdateSlaPolicyCmd,
+)
 from libzapi.domain.models.ticketing.sla_policies import SlaPolicy
 from libzapi.infrastructure.http.client import HttpClient
 from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.mappers.ticketing.sla_policy_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
 from libzapi.infrastructure.serialization.parse import to_domain
 
 
@@ -23,6 +31,36 @@ class SlaPolicyApiClient:
         ):
             yield to_domain(data=obj, cls=SlaPolicy)
 
+    def list_definitions(self) -> dict:
+        return self._http.get("/api/v2/slas/policies/definitions")
+
     def get(self, sla_policy_id: int) -> SlaPolicy:
         data = self._http.get(f"/api/v2/slas/policies/{int(sla_policy_id)}")
         return to_domain(data=data["sla_policy"], cls=SlaPolicy)
+
+    def create(self, entity: CreateSlaPolicyCmd) -> SlaPolicy:
+        payload = to_payload_create(entity)
+        data = self._http.post("/api/v2/slas/policies", payload)
+        return to_domain(data=data["sla_policy"], cls=SlaPolicy)
+
+    def update(
+        self, sla_policy_id: int, entity: UpdateSlaPolicyCmd
+    ) -> SlaPolicy:
+        payload = to_payload_update(entity)
+        data = self._http.put(
+            f"/api/v2/slas/policies/{int(sla_policy_id)}", payload
+        )
+        return to_domain(data=data["sla_policy"], cls=SlaPolicy)
+
+    def delete(self, sla_policy_id: int) -> None:
+        self._http.delete(f"/api/v2/slas/policies/{int(sla_policy_id)}")
+
+    def reorder(self, sla_policy_ids: Iterable[int]) -> list[SlaPolicy]:
+        ids = [int(i) for i in sla_policy_ids]
+        data = self._http.put(
+            "/api/v2/slas/policies/reorder", {"sla_policy_ids": ids}
+        )
+        return [
+            to_domain(data=obj, cls=SlaPolicy)
+            for obj in data.get("sla_policies", [])
+        ]

--- a/libzapi/infrastructure/mappers/ticketing/sla_policy_mapper.py
+++ b/libzapi/infrastructure/mappers/ticketing/sla_policy_mapper.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from libzapi.application.commands.ticketing.sla_policy_cmds import (
+    CreateSlaPolicyCmd,
+    UpdateSlaPolicyCmd,
+)
+
+
+def to_payload_create(cmd: CreateSlaPolicyCmd) -> dict:
+    body: dict = {
+        "title": cmd.title,
+        "filter": cmd.filter,
+        "policy_metrics": list(cmd.policy_metrics),
+    }
+    if cmd.description is not None:
+        body["description"] = cmd.description
+    if cmd.position is not None:
+        body["position"] = cmd.position
+    return {"sla_policy": body}
+
+
+def to_payload_update(cmd: UpdateSlaPolicyCmd) -> dict:
+    body: dict = {}
+    if cmd.title is not None:
+        body["title"] = cmd.title
+    if cmd.filter is not None:
+        body["filter"] = cmd.filter
+    if cmd.policy_metrics is not None:
+        body["policy_metrics"] = list(cmd.policy_metrics)
+    if cmd.description is not None:
+        body["description"] = cmd.description
+    if cmd.position is not None:
+        body["position"] = cmd.position
+    return {"sla_policy": body}

--- a/tests/integration/ticketing/test_sla_policy.py
+++ b/tests/integration/ticketing/test_sla_policy.py
@@ -1,8 +1,65 @@
+import itertools
+import uuid
+
 from libzapi import Ticketing
 
 
+_METRICS = [
+    {
+        "priority": "low",
+        "metric": "first_reply_time",
+        "target": 480,
+        "business_hours": False,
+    }
+]
+
+
+def _unique() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+def _create_policy(ticketing: Ticketing, **overrides):
+    suffix = _unique()
+    defaults = dict(
+        title=f"libzapi sla {suffix}",
+        filter={
+            "all": [{"field": "type", "operator": "is", "value": "incident"}],
+            "any": [],
+        },
+        policy_metrics=list(_METRICS),
+    )
+    defaults.update(overrides)
+    return ticketing.sla_policies.create(**defaults)
+
+
 def test_list_and_get_sla_policy(ticketing: Ticketing):
-    items = list(ticketing.sla_policies.list())
+    items = list(itertools.islice(ticketing.sla_policies.list(), 20))
     assert len(items) > 0
     item = ticketing.sla_policies.get(items[0].id)
     assert item.title == items[0].title
+
+
+def test_list_definitions(ticketing: Ticketing):
+    defs = ticketing.sla_policies.list_definitions()
+    assert isinstance(defs, dict)
+
+
+def test_create_update_delete(ticketing: Ticketing):
+    policy = _create_policy(ticketing, description="created by libzapi")
+    assert policy.id > 0
+    updated = ticketing.sla_policies.update(
+        policy.id, description="updated by libzapi"
+    )
+    assert updated.description == "updated by libzapi"
+    ticketing.sla_policies.delete(policy.id)
+
+
+def test_reorder(ticketing: Ticketing):
+    a = _create_policy(ticketing)
+    b = _create_policy(ticketing)
+    try:
+        reordered = ticketing.sla_policies.reorder([b.id, a.id])
+        assert isinstance(reordered, list)
+    finally:
+        ticketing.sla_policies.delete(a.id)
+        ticketing.sla_policies.delete(b.id)

--- a/tests/unit/ticketing/test_sla_policies_service.py
+++ b/tests/unit/ticketing/test_sla_policies_service.py
@@ -1,0 +1,131 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.commands.ticketing.sla_policy_cmds import (
+    CreateSlaPolicyCmd,
+    UpdateSlaPolicyCmd,
+)
+from libzapi.application.services.ticketing.sla_policies_service import (
+    SlaPoliciesService,
+)
+from libzapi.domain.errors import NotFound, RateLimited, Unauthorized, UnprocessableEntity
+
+
+_FILTER = {"all": [], "any": []}
+_METRICS = [
+    {
+        "priority": "low",
+        "metric": "first_reply_time",
+        "target": 480,
+        "business_hours": False,
+    }
+]
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return SlaPoliciesService(client), client
+
+
+class TestDelegation:
+    def test_list_delegates(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.items
+        assert service.list() is sentinel.items
+
+    def test_list_definitions_delegates(self):
+        service, client = _make_service()
+        client.list_definitions.return_value = {"x": 1}
+        assert service.list_definitions() == {"x": 1}
+
+    def test_get_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.item
+        assert service.get(5) is sentinel.item
+        client.get.assert_called_once_with(sla_policy_id=5)
+
+    def test_delete_delegates(self):
+        service, client = _make_service()
+        service.delete(5)
+        client.delete.assert_called_once_with(sla_policy_id=5)
+
+    def test_reorder_delegates(self):
+        service, client = _make_service()
+        client.reorder.return_value = sentinel.reordered
+        assert service.reorder([1, 2]) is sentinel.reordered
+        client.reorder.assert_called_once_with(sla_policy_ids=[1, 2])
+
+
+class TestCreate:
+    def test_builds_create_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.create.return_value = sentinel.item
+        result = service.create(
+            title="T", filter=_FILTER, policy_metrics=_METRICS
+        )
+        cmd = client.create.call_args.kwargs["entity"]
+        assert isinstance(cmd, CreateSlaPolicyCmd)
+        assert cmd.title == "T"
+        assert cmd.filter == _FILTER
+        assert cmd.policy_metrics == _METRICS
+        assert result is sentinel.item
+
+    def test_passes_all_optional_fields(self):
+        service, client = _make_service()
+        service.create(
+            title="T",
+            filter=_FILTER,
+            policy_metrics=_METRICS,
+            description="d",
+            position=3,
+        )
+        cmd = client.create.call_args.kwargs["entity"]
+        assert cmd.description == "d"
+        assert cmd.position == 3
+
+
+class TestUpdate:
+    def test_builds_update_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.update.return_value = sentinel.item
+        result = service.update(7, description="updated")
+        assert client.update.call_args.kwargs["sla_policy_id"] == 7
+        cmd = client.update.call_args.kwargs["entity"]
+        assert isinstance(cmd, UpdateSlaPolicyCmd)
+        assert cmd.description == "updated"
+        assert result is sentinel.item
+
+    def test_empty_fields_yields_blank_cmd(self):
+        service, client = _make_service()
+        service.update(1)
+        cmd = client.update.call_args.kwargs["entity"]
+        assert cmd.title is None
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize(
+        "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+    )
+    def test_create_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.create.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.create(
+                title="t", filter=_FILTER, policy_metrics=_METRICS
+            )
+
+    @pytest.mark.parametrize(
+        "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+    )
+    def test_update_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.update.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.update(1)
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.list.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list()

--- a/tests/unit/ticketing/test_sla_policy.py
+++ b/tests/unit/ticketing/test_sla_policy.py
@@ -1,7 +1,15 @@
+import pytest
 from hypothesis import given
 from hypothesis.strategies import just, builds
 
+from libzapi.application.commands.ticketing.sla_policy_cmds import (
+    CreateSlaPolicyCmd,
+    UpdateSlaPolicyCmd,
+)
+from libzapi.domain.errors import NotFound, RateLimited, Unauthorized, UnprocessableEntity
 from libzapi.domain.models.ticketing.sla_policies import SlaPolicy
+from libzapi.infrastructure.api_clients.ticketing import SlaPolicyApiClient
+
 
 strategy = builds(
     SlaPolicy,
@@ -12,3 +20,159 @@ strategy = builds(
 @given(strategy)
 def test_session_logical_key_from_id(model: SlaPolicy):
     assert model.logical_key.as_str() == "sla_policy:sample"
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.sla_policy_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+_FILTER = {"all": [], "any": []}
+_METRICS = [
+    {
+        "priority": "low",
+        "metric": "first_reply_time",
+        "target": 480,
+        "business_hours": False,
+    }
+]
+
+
+# ---------------------------------------------------------------------------
+# Listing / pagination
+# ---------------------------------------------------------------------------
+
+
+def test_list_endpoint(mocker):
+    https = mocker.Mock()
+    https.base_url = "https://example.zendesk.com"
+    https.get.return_value = {"sla_policies": []}
+    client = SlaPolicyApiClient(https)
+    list(client.list())
+    https.get.assert_called_with("/api/v2/slas/policies")
+
+
+def test_list_yields_items(http, domain):
+    http.get.return_value = {
+        "sla_policies": [{"id": 1}, {"id": 2}],
+        "meta": {"has_more": False},
+        "links": {"next": None},
+    }
+    client = SlaPolicyApiClient(http)
+    assert len(list(client.list())) == 2
+
+
+# ---------------------------------------------------------------------------
+# Simple endpoints
+# ---------------------------------------------------------------------------
+
+
+def test_list_definitions_returns_dict(http):
+    http.get.return_value = {"definitions": {}}
+    client = SlaPolicyApiClient(http)
+    assert client.list_definitions() == {"definitions": {}}
+    http.get.assert_called_with("/api/v2/slas/policies/definitions")
+
+
+def test_get_returns_domain(http, domain):
+    http.get.return_value = {"sla_policy": {"id": 5}}
+    client = SlaPolicyApiClient(http)
+    result = client.get(sla_policy_id=5)
+    http.get.assert_called_with("/api/v2/slas/policies/5")
+    assert result["id"] == 5
+
+
+# ---------------------------------------------------------------------------
+# create / update / delete
+# ---------------------------------------------------------------------------
+
+
+def test_create_posts_payload(http, domain):
+    http.post.return_value = {"sla_policy": {"id": 1}}
+    client = SlaPolicyApiClient(http)
+    client.create(
+        CreateSlaPolicyCmd(
+            title="T", filter=_FILTER, policy_metrics=_METRICS
+        )
+    )
+    http.post.assert_called_with(
+        "/api/v2/slas/policies",
+        {
+            "sla_policy": {
+                "title": "T",
+                "filter": _FILTER,
+                "policy_metrics": _METRICS,
+            }
+        },
+    )
+
+
+def test_update_puts_payload(http, domain):
+    http.put.return_value = {"sla_policy": {"id": 1, "description": "d"}}
+    client = SlaPolicyApiClient(http)
+    client.update(sla_policy_id=1, entity=UpdateSlaPolicyCmd(description="d"))
+    http.put.assert_called_with(
+        "/api/v2/slas/policies/1", {"sla_policy": {"description": "d"}}
+    )
+
+
+def test_delete_calls_delete(http):
+    client = SlaPolicyApiClient(http)
+    client.delete(sla_policy_id=7)
+    http.delete.assert_called_with("/api/v2/slas/policies/7")
+
+
+# ---------------------------------------------------------------------------
+# Reorder
+# ---------------------------------------------------------------------------
+
+
+def test_reorder_puts_ids(http, domain):
+    http.put.return_value = {
+        "sla_policies": [{"id": 1}, {"id": 2}]
+    }
+    client = SlaPolicyApiClient(http)
+    result = client.reorder([2, 1])
+    http.put.assert_called_with(
+        "/api/v2/slas/policies/reorder", {"sla_policy_ids": [2, 1]}
+    )
+    assert len(result) == 2
+
+
+def test_reorder_handles_missing_key(http, domain):
+    http.put.return_value = {}
+    client = SlaPolicyApiClient(http)
+    assert client.reorder([1]) == []
+
+
+# ---------------------------------------------------------------------------
+# Error propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error_cls",
+    [
+        pytest.param(Unauthorized, id="401"),
+        pytest.param(NotFound, id="404"),
+        pytest.param(UnprocessableEntity, id="422"),
+        pytest.param(RateLimited, id="429"),
+    ],
+)
+def test_raises_on_http_error(error_cls, mocker):
+    https = mocker.Mock()
+    https.base_url = "https://example.zendesk.com"
+    https.get.side_effect = error_cls("error")
+    client = SlaPolicyApiClient(https)
+    with pytest.raises(error_cls):
+        list(client.list())

--- a/tests/unit/ticketing/test_sla_policy_mapper.py
+++ b/tests/unit/ticketing/test_sla_policy_mapper.py
@@ -1,0 +1,95 @@
+from libzapi.application.commands.ticketing.sla_policy_cmds import (
+    CreateSlaPolicyCmd,
+    UpdateSlaPolicyCmd,
+)
+from libzapi.infrastructure.mappers.ticketing.sla_policy_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
+
+
+_FILTER = {"all": [], "any": []}
+_METRICS = [
+    {
+        "priority": "low",
+        "metric": "first_reply_time",
+        "target": 480,
+        "business_hours": False,
+    }
+]
+
+
+def test_create_minimal_payload_only_includes_required():
+    payload = to_payload_create(
+        CreateSlaPolicyCmd(
+            title="T", filter=_FILTER, policy_metrics=_METRICS
+        )
+    )
+    assert payload == {
+        "sla_policy": {
+            "title": "T",
+            "filter": _FILTER,
+            "policy_metrics": _METRICS,
+        }
+    }
+
+
+def test_create_includes_all_optional_fields():
+    body = to_payload_create(
+        CreateSlaPolicyCmd(
+            title="T",
+            filter=_FILTER,
+            policy_metrics=_METRICS,
+            description="d",
+            position=3,
+        )
+    )["sla_policy"]
+    assert body["description"] == "d"
+    assert body["position"] == 3
+
+
+def test_create_skips_none_optional_fields():
+    body = to_payload_create(
+        CreateSlaPolicyCmd(title="T", filter=_FILTER, policy_metrics=_METRICS)
+    )["sla_policy"]
+    assert "description" not in body
+    assert "position" not in body
+
+
+def test_create_converts_metrics_iterable_to_list():
+    body = to_payload_create(
+        CreateSlaPolicyCmd(
+            title="T", filter=_FILTER, policy_metrics=iter(_METRICS)
+        )
+    )["sla_policy"]
+    assert body["policy_metrics"] == _METRICS
+
+
+def test_update_empty_cmd_returns_empty_patch():
+    assert to_payload_update(UpdateSlaPolicyCmd()) == {"sla_policy": {}}
+
+
+def test_update_includes_all_fields():
+    body = to_payload_update(
+        UpdateSlaPolicyCmd(
+            title="New",
+            filter=_FILTER,
+            policy_metrics=_METRICS,
+            description="d",
+            position=5,
+        )
+    )["sla_policy"]
+    assert body == {
+        "title": "New",
+        "filter": _FILTER,
+        "policy_metrics": _METRICS,
+        "description": "d",
+        "position": 5,
+    }
+
+
+def test_update_converts_metrics_iterable_to_list():
+    body = to_payload_update(
+        UpdateSlaPolicyCmd(policy_metrics=iter(_METRICS))
+    )["sla_policy"]
+    assert body["policy_metrics"] == _METRICS


### PR DESCRIPTION
## Summary
- Adds \`CreateSlaPolicyCmd\` / \`UpdateSlaPolicyCmd\` and a mapper that skips unset optionals
- Extends \`SlaPolicyApiClient\` with \`create\`, \`update\`, \`delete\`, \`reorder\`, \`list_definitions\`
- \`SlaPoliciesService\` exposes a \`**fields\` kwargs API consistent with the rest of the CUD series
- 100% unit coverage across all five SLA policy modules (122 stmts); integration tests exercise every endpoint against a live tenant

Refs #79

## Test plan
- [x] \`uv run pytest tests/unit/ticketing/test_sla_policy.py tests/unit/ticketing/test_sla_policy_mapper.py tests/unit/ticketing/test_sla_policies_service.py\` — 40 pass
- [x] Full unit suite: 1893 pass
- [x] Coverage: 122/122 statements
- [ ] Integration tests against live tenant (gated, verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)