### PR TITLE
feat(ticketing): add ticket forms CUD, clone, reorder

### DIFF
--- a/libzapi/application/commands/ticketing/ticket_form_cmds.py
+++ b/libzapi/application/commands/ticketing/ticket_form_cmds.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, TypeAlias
+
+
+@dataclass(frozen=True, slots=True)
+class CreateTicketFormCmd:
+    name: str
+    ticket_field_ids: Iterable[int]
+    display_name: str | None = None
+    end_user_visible: bool | None = None
+    position: int | None = None
+    active: bool | None = None
+    default: bool | None = None
+    in_all_brands: bool | None = None
+    restricted_brand_ids: Iterable[int] | None = None
+    end_user_conditions: Iterable[dict[str, Any]] | None = None
+    agent_conditions: Iterable[dict[str, Any]] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateTicketFormCmd:
+    name: str | None = None
+    ticket_field_ids: Iterable[int] | None = None
+    display_name: str | None = None
+    end_user_visible: bool | None = None
+    position: int | None = None
+    active: bool | None = None
+    default: bool | None = None
+    in_all_brands: bool | None = None
+    restricted_brand_ids: Iterable[int] | None = None
+    end_user_conditions: Iterable[dict[str, Any]] | None = None
+    agent_conditions: Iterable[dict[str, Any]] | None = None
+
+
+TicketFormCmd: TypeAlias = CreateTicketFormCmd | UpdateTicketFormCmd

--- a/libzapi/application/services/ticketing/ticket_forms_service.py
+++ b/libzapi/application/services/ticketing/ticket_forms_service.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
 from typing import Iterable
 
+from libzapi.application.commands.ticketing.ticket_form_cmds import (
+    CreateTicketFormCmd,
+    UpdateTicketFormCmd,
+)
 from libzapi.domain.models.ticketing.ticket_form import TicketForm
-from libzapi.infrastructure.api_clients.ticketing.ticket_form_api_client import TicketFormApiClient
+from libzapi.infrastructure.api_clients.ticketing.ticket_form_api_client import (
+    TicketFormApiClient,
+)
 
 
 class TicketFormsService:
@@ -14,4 +22,21 @@ class TicketFormsService:
         return self._client.list()
 
     def get_by_id(self, ticket_form_id: int) -> TicketForm:
-        return self._client.get(ticket_form_id)
+        return self._client.get(ticket_form_id=ticket_form_id)
+
+    def create(self, **fields) -> TicketForm:
+        return self._client.create(entity=CreateTicketFormCmd(**fields))
+
+    def update(self, ticket_form_id: int, **fields) -> TicketForm:
+        return self._client.update(
+            ticket_form_id=ticket_form_id, entity=UpdateTicketFormCmd(**fields)
+        )
+
+    def delete(self, ticket_form_id: int) -> None:
+        self._client.delete(ticket_form_id=ticket_form_id)
+
+    def clone(self, ticket_form_id: int) -> TicketForm:
+        return self._client.clone(ticket_form_id=ticket_form_id)
+
+    def reorder(self, ticket_form_ids: Iterable[int]) -> None:
+        self._client.reorder(ticket_form_ids=ticket_form_ids)

--- a/libzapi/infrastructure/api_clients/ticketing/ticket_form_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/ticket_form_api_client.py
@@ -1,19 +1,28 @@
 from __future__ import annotations
-from typing import Iterable
 
+from typing import Iterable, Iterator
+
+from libzapi.application.commands.ticketing.ticket_form_cmds import (
+    CreateTicketFormCmd,
+    UpdateTicketFormCmd,
+)
 from libzapi.domain.models.ticketing.ticket_form import TicketForm
 from libzapi.infrastructure.http.client import HttpClient
 from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.mappers.ticketing.ticket_form_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
 from libzapi.infrastructure.serialization.parse import to_domain
 
 
 class TicketFormApiClient:
-    """HTTP adapter for Zendesk Groups with shared cursor pagination."""
+    """HTTP adapter for Zendesk Ticket Forms with shared cursor pagination."""
 
     def __init__(self, http: HttpClient) -> None:
         self._http = http
 
-    def list(self) -> Iterable[TicketForm]:
+    def list(self) -> Iterator[TicketForm]:
         for obj in yield_items(
             get_json=self._http.get,
             first_path="/api/v2/ticket_forms",
@@ -25,3 +34,28 @@ class TicketFormApiClient:
     def get(self, ticket_form_id: int) -> TicketForm:
         data = self._http.get(f"/api/v2/ticket_forms/{int(ticket_form_id)}")
         return to_domain(data=data["ticket_form"], cls=TicketForm)
+
+    def create(self, entity: CreateTicketFormCmd) -> TicketForm:
+        payload = to_payload_create(entity)
+        data = self._http.post("/api/v2/ticket_forms", payload)
+        return to_domain(data=data["ticket_form"], cls=TicketForm)
+
+    def update(self, ticket_form_id: int, entity: UpdateTicketFormCmd) -> TicketForm:
+        payload = to_payload_update(entity)
+        data = self._http.put(
+            f"/api/v2/ticket_forms/{int(ticket_form_id)}", payload
+        )
+        return to_domain(data=data["ticket_form"], cls=TicketForm)
+
+    def delete(self, ticket_form_id: int) -> None:
+        self._http.delete(f"/api/v2/ticket_forms/{int(ticket_form_id)}")
+
+    def clone(self, ticket_form_id: int) -> TicketForm:
+        data = self._http.post(
+            f"/api/v2/ticket_forms/{int(ticket_form_id)}/clone", {}
+        )
+        return to_domain(data=data["ticket_form"], cls=TicketForm)
+
+    def reorder(self, ticket_form_ids: Iterable[int]) -> None:
+        payload = {"ticket_form_ids": [int(i) for i in ticket_form_ids]}
+        self._http.put("/api/v2/ticket_forms/reorder", payload)

--- a/libzapi/infrastructure/mappers/ticketing/ticket_form_mapper.py
+++ b/libzapi/infrastructure/mappers/ticketing/ticket_form_mapper.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from libzapi.application.commands.ticketing.ticket_form_cmds import (
+    CreateTicketFormCmd,
+    UpdateTicketFormCmd,
+)
+
+
+def _add_optionals(body: dict, cmd: CreateTicketFormCmd | UpdateTicketFormCmd) -> None:
+    if cmd.display_name is not None:
+        body["display_name"] = cmd.display_name
+    if cmd.end_user_visible is not None:
+        body["end_user_visible"] = cmd.end_user_visible
+    if cmd.position is not None:
+        body["position"] = cmd.position
+    if cmd.active is not None:
+        body["active"] = cmd.active
+    if cmd.default is not None:
+        body["default"] = cmd.default
+    if cmd.in_all_brands is not None:
+        body["in_all_brands"] = cmd.in_all_brands
+    if cmd.restricted_brand_ids is not None:
+        body["restricted_brand_ids"] = [int(i) for i in cmd.restricted_brand_ids]
+    if cmd.end_user_conditions is not None:
+        body["end_user_conditions"] = list(cmd.end_user_conditions)
+    if cmd.agent_conditions is not None:
+        body["agent_conditions"] = list(cmd.agent_conditions)
+
+
+def to_payload_create(cmd: CreateTicketFormCmd) -> dict:
+    body: dict = {
+        "name": cmd.name,
+        "ticket_field_ids": [int(i) for i in cmd.ticket_field_ids],
+    }
+    _add_optionals(body, cmd)
+    return {"ticket_form": body}
+
+
+def to_payload_update(cmd: UpdateTicketFormCmd) -> dict:
+    body: dict = {}
+    if cmd.name is not None:
+        body["name"] = cmd.name
+    if cmd.ticket_field_ids is not None:
+        body["ticket_field_ids"] = [int(i) for i in cmd.ticket_field_ids]
+    _add_optionals(body, cmd)
+    return {"ticket_form": body}

--- a/tests/integration/ticketing/test_ticket_form.py
+++ b/tests/integration/ticketing/test_ticket_form.py
@@ -1,0 +1,59 @@
+import itertools
+import uuid
+
+from libzapi import Ticketing
+
+
+def _unique() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+def _pick_a_field_id(ticketing: Ticketing) -> int:
+    return next(iter(ticketing.ticket_fields.list_all())).id
+
+
+def _create_form(ticketing: Ticketing, **overrides):
+    suffix = _unique()
+    defaults = dict(
+        name=f"libzapi form {suffix}",
+        ticket_field_ids=[_pick_a_field_id(ticketing)],
+    )
+    defaults.update(overrides)
+    return ticketing.ticket_forms.create(**defaults)
+
+
+def test_list_and_get_ticket_form(ticketing: Ticketing):
+    forms = list(itertools.islice(ticketing.ticket_forms.list_all(), 20))
+    assert len(forms) > 0
+    form = ticketing.ticket_forms.get_by_id(forms[0].id)
+    assert form.name == forms[0].name
+
+
+def test_create_update_delete_form(ticketing: Ticketing):
+    form = _create_form(ticketing, end_user_visible=False)
+    assert form.id > 0
+    try:
+        updated = ticketing.ticket_forms.update(
+            form.id, display_name="libzapi updated", active=False
+        )
+        assert updated.active is False
+    finally:
+        ticketing.ticket_forms.delete(form.id)
+
+
+def test_clone_form(ticketing: Ticketing):
+    form = _create_form(ticketing)
+    try:
+        clone = ticketing.ticket_forms.clone(form.id)
+        try:
+            assert clone.id != form.id
+        finally:
+            ticketing.ticket_forms.delete(clone.id)
+    finally:
+        ticketing.ticket_forms.delete(form.id)
+
+
+def test_reorder_does_not_raise(ticketing: Ticketing):
+    forms = list(itertools.islice(ticketing.ticket_forms.list_all(), 5))
+    ids = [f.id for f in forms]
+    ticketing.ticket_forms.reorder(ids)

--- a/tests/unit/ticketing/test_ticket_form.py
+++ b/tests/unit/ticketing/test_ticket_form.py
@@ -38,6 +38,31 @@ def test_ticket_form_api_client_get(mocker):
     https.get.assert_called_with("/api/v2/ticket_forms/88")
 
 
+def test_ticket_form_logical_key_normalises_raw_name():
+    from datetime import datetime
+
+    from libzapi.domain.models.ticketing.ticket_form import TicketForm
+
+    form = TicketForm(
+        id=1,
+        raw_name="Default Form",
+        raw_display_name="Default",
+        end_user_visible=True,
+        position=1,
+        ticket_field_ids=[],
+        active=True,
+        default=True,
+        in_all_brands=True,
+        restricted_brand_ids=[],
+        url="https://x",
+        name="Default Form",
+        display_name="Default",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    assert form.logical_key.as_str() == "ticket_form:default_form"
+
+
 @pytest.mark.parametrize(
     "error_cls",
     [

--- a/tests/unit/ticketing/test_ticket_form_client.py
+++ b/tests/unit/ticketing/test_ticket_form_client.py
@@ -1,0 +1,141 @@
+import pytest
+
+from libzapi.application.commands.ticketing.ticket_form_cmds import (
+    CreateTicketFormCmd,
+    UpdateTicketFormCmd,
+)
+from libzapi.domain.errors import (
+    NotFound,
+    RateLimited,
+    Unauthorized,
+    UnprocessableEntity,
+)
+from libzapi.infrastructure.api_clients.ticketing import TicketFormApiClient
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.ticket_form_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Listing / pagination
+# ---------------------------------------------------------------------------
+
+
+def test_list_yields_items(http, domain):
+    http.get.return_value = {
+        "ticket_forms": [{"id": 1}, {"id": 2}],
+        "meta": {"has_more": False},
+        "links": {"next": None},
+    }
+    client = TicketFormApiClient(http)
+    result = list(client.list())
+    http.get.assert_called_with("/api/v2/ticket_forms")
+    assert len(result) == 2
+    assert result[0]["id"] == 1
+
+
+def test_get_returns_domain(http, domain):
+    http.get.return_value = {"ticket_form": {"id": 5}}
+    client = TicketFormApiClient(http)
+    result = client.get(ticket_form_id=5)
+    http.get.assert_called_with("/api/v2/ticket_forms/5")
+    assert result["id"] == 5
+
+
+# ---------------------------------------------------------------------------
+# create / update / delete
+# ---------------------------------------------------------------------------
+
+
+def test_create_posts_payload(http, domain):
+    http.post.return_value = {"ticket_form": {"id": 1, "name": "F"}}
+    client = TicketFormApiClient(http)
+    result = client.create(
+        CreateTicketFormCmd(name="F", ticket_field_ids=[1, 2])
+    )
+    http.post.assert_called_with(
+        "/api/v2/ticket_forms",
+        {"ticket_form": {"name": "F", "ticket_field_ids": [1, 2]}},
+    )
+    assert result["name"] == "F"
+
+
+def test_update_puts_payload(http, domain):
+    http.put.return_value = {"ticket_form": {"id": 1, "active": False}}
+    client = TicketFormApiClient(http)
+    client.update(ticket_form_id=1, entity=UpdateTicketFormCmd(active=False))
+    http.put.assert_called_with(
+        "/api/v2/ticket_forms/1", {"ticket_form": {"active": False}}
+    )
+
+
+def test_delete_calls_delete(http):
+    client = TicketFormApiClient(http)
+    client.delete(ticket_form_id=7)
+    http.delete.assert_called_with("/api/v2/ticket_forms/7")
+
+
+# ---------------------------------------------------------------------------
+# clone / reorder
+# ---------------------------------------------------------------------------
+
+
+def test_clone_posts_empty_body(http, domain):
+    http.post.return_value = {"ticket_form": {"id": 9}}
+    client = TicketFormApiClient(http)
+    result = client.clone(ticket_form_id=5)
+    http.post.assert_called_with("/api/v2/ticket_forms/5/clone", {})
+    assert result["id"] == 9
+
+
+def test_reorder_puts_ids(http):
+    client = TicketFormApiClient(http)
+    client.reorder(ticket_form_ids=[3, 1, 2])
+    http.put.assert_called_with(
+        "/api/v2/ticket_forms/reorder", {"ticket_form_ids": [3, 1, 2]}
+    )
+
+
+def test_reorder_converts_iterable(http):
+    client = TicketFormApiClient(http)
+    client.reorder(ticket_form_ids=iter([3, 1]))
+    http.put.assert_called_with(
+        "/api/v2/ticket_forms/reorder", {"ticket_form_ids": [3, 1]}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Error propagation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error_cls",
+    [
+        pytest.param(Unauthorized, id="401"),
+        pytest.param(NotFound, id="404"),
+        pytest.param(UnprocessableEntity, id="422"),
+        pytest.param(RateLimited, id="429"),
+    ],
+)
+def test_ticket_form_api_client_raises_on_http_error(error_cls, mocker):
+    https = mocker.Mock()
+    https.base_url = "https://example.zendesk.com"
+    https.get.side_effect = error_cls("error")
+
+    client = TicketFormApiClient(https)
+
+    with pytest.raises(error_cls):
+        list(client.list())

--- a/tests/unit/ticketing/test_ticket_form_mapper.py
+++ b/tests/unit/ticketing/test_ticket_form_mapper.py
@@ -1,0 +1,150 @@
+from libzapi.application.commands.ticketing.ticket_form_cmds import (
+    CreateTicketFormCmd,
+    UpdateTicketFormCmd,
+)
+from libzapi.infrastructure.mappers.ticketing.ticket_form_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
+
+
+# ---------------------------------------------------------------------------
+# to_payload_create
+# ---------------------------------------------------------------------------
+
+
+def test_create_minimal_payload_only_includes_required():
+    payload = to_payload_create(
+        CreateTicketFormCmd(name="Default", ticket_field_ids=[1, 2])
+    )
+    assert payload == {
+        "ticket_form": {"name": "Default", "ticket_field_ids": [1, 2]}
+    }
+
+
+def test_create_includes_all_optional_fields():
+    cmd = CreateTicketFormCmd(
+        name="Default",
+        ticket_field_ids=[1, 2],
+        display_name="Public",
+        end_user_visible=True,
+        position=3,
+        active=True,
+        default=True,
+        in_all_brands=True,
+        restricted_brand_ids=[10, 20],
+        end_user_conditions=[{"parent_field_id": 1, "value": "yes"}],
+        agent_conditions=[{"parent_field_id": 2, "value": "no"}],
+    )
+
+    body = to_payload_create(cmd)["ticket_form"]
+
+    assert body["name"] == "Default"
+    assert body["ticket_field_ids"] == [1, 2]
+    assert body["display_name"] == "Public"
+    assert body["end_user_visible"] is True
+    assert body["position"] == 3
+    assert body["active"] is True
+    assert body["default"] is True
+    assert body["in_all_brands"] is True
+    assert body["restricted_brand_ids"] == [10, 20]
+    assert body["end_user_conditions"] == [{"parent_field_id": 1, "value": "yes"}]
+    assert body["agent_conditions"] == [{"parent_field_id": 2, "value": "no"}]
+
+
+def test_create_preserves_false_booleans():
+    body = to_payload_create(
+        CreateTicketFormCmd(
+            name="n",
+            ticket_field_ids=[1],
+            end_user_visible=False,
+            active=False,
+            default=False,
+            in_all_brands=False,
+        )
+    )["ticket_form"]
+    assert body["end_user_visible"] is False
+    assert body["active"] is False
+    assert body["default"] is False
+    assert body["in_all_brands"] is False
+
+
+def test_create_skips_none_optional_fields():
+    body = to_payload_create(
+        CreateTicketFormCmd(name="n", ticket_field_ids=[1])
+    )["ticket_form"]
+    assert set(body.keys()) == {"name", "ticket_field_ids"}
+
+
+def test_create_converts_iterables_to_lists():
+    cmd = CreateTicketFormCmd(
+        name="n",
+        ticket_field_ids=iter([1, 2]),
+        restricted_brand_ids=iter([7]),
+        end_user_conditions=iter([{"a": 1}]),
+        agent_conditions=iter([{"b": 2}]),
+    )
+    body = to_payload_create(cmd)["ticket_form"]
+    assert body["ticket_field_ids"] == [1, 2]
+    assert body["restricted_brand_ids"] == [7]
+    assert body["end_user_conditions"] == [{"a": 1}]
+    assert body["agent_conditions"] == [{"b": 2}]
+
+
+# ---------------------------------------------------------------------------
+# to_payload_update
+# ---------------------------------------------------------------------------
+
+
+def test_update_empty_cmd_returns_empty_patch():
+    assert to_payload_update(UpdateTicketFormCmd()) == {"ticket_form": {}}
+
+
+def test_update_includes_all_fields():
+    cmd = UpdateTicketFormCmd(
+        name="New",
+        ticket_field_ids=[3],
+        display_name="Public",
+        end_user_visible=True,
+        position=1,
+        active=True,
+        default=True,
+        in_all_brands=True,
+        restricted_brand_ids=[5],
+        end_user_conditions=[{"a": 1}],
+        agent_conditions=[{"b": 2}],
+    )
+    body = to_payload_update(cmd)["ticket_form"]
+    assert body == {
+        "name": "New",
+        "ticket_field_ids": [3],
+        "display_name": "Public",
+        "end_user_visible": True,
+        "position": 1,
+        "active": True,
+        "default": True,
+        "in_all_brands": True,
+        "restricted_brand_ids": [5],
+        "end_user_conditions": [{"a": 1}],
+        "agent_conditions": [{"b": 2}],
+    }
+
+
+def test_update_preserves_false_booleans():
+    body = to_payload_update(UpdateTicketFormCmd(active=False))["ticket_form"]
+    assert body == {"active": False}
+
+
+def test_update_converts_iterables_to_lists():
+    body = to_payload_update(
+        UpdateTicketFormCmd(
+            ticket_field_ids=iter([9]),
+            restricted_brand_ids=iter([3]),
+            end_user_conditions=iter([{"a": 1}]),
+            agent_conditions=iter([{"b": 2}]),
+        )
+    )["ticket_form"]
+    assert body["ticket_field_ids"] == [9]
+    assert body["restricted_brand_ids"] == [3]
+    assert body["end_user_conditions"] == [{"a": 1}]
+    assert body["agent_conditions"] == [{"b": 2}]

--- a/tests/unit/ticketing/test_ticket_form_service.py
+++ b/tests/unit/ticketing/test_ticket_form_service.py
@@ -1,0 +1,129 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.commands.ticketing.ticket_form_cmds import (
+    CreateTicketFormCmd,
+    UpdateTicketFormCmd,
+)
+from libzapi.application.services.ticketing.ticket_forms_service import (
+    TicketFormsService,
+)
+from libzapi.domain.errors import (
+    NotFound,
+    RateLimited,
+    Unauthorized,
+    UnprocessableEntity,
+)
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return TicketFormsService(client), client
+
+
+class TestDelegation:
+    def test_list_all_delegates(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.forms
+        assert service.list_all() is sentinel.forms
+
+    def test_get_by_id_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.form
+        assert service.get_by_id(5) is sentinel.form
+        client.get.assert_called_once_with(ticket_form_id=5)
+
+    def test_delete_delegates(self):
+        service, client = _make_service()
+        service.delete(5)
+        client.delete.assert_called_once_with(ticket_form_id=5)
+
+    def test_clone_delegates(self):
+        service, client = _make_service()
+        client.clone.return_value = sentinel.form
+        assert service.clone(5) is sentinel.form
+        client.clone.assert_called_once_with(ticket_form_id=5)
+
+    def test_reorder_delegates(self):
+        service, client = _make_service()
+        service.reorder([3, 1, 2])
+        client.reorder.assert_called_once_with(ticket_form_ids=[3, 1, 2])
+
+
+class TestCreate:
+    def test_builds_create_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.create.return_value = sentinel.form
+
+        result = service.create(name="F", ticket_field_ids=[1])
+
+        cmd = client.create.call_args.kwargs["entity"]
+        assert isinstance(cmd, CreateTicketFormCmd)
+        assert cmd.name == "F"
+        assert cmd.ticket_field_ids == [1]
+        assert result is sentinel.form
+
+    def test_passes_all_optional_fields(self):
+        service, client = _make_service()
+        service.create(
+            name="F",
+            ticket_field_ids=[1],
+            display_name="Public",
+            end_user_visible=False,
+            in_all_brands=True,
+            restricted_brand_ids=[9],
+        )
+        cmd = client.create.call_args.kwargs["entity"]
+        assert cmd.display_name == "Public"
+        assert cmd.end_user_visible is False
+        assert cmd.in_all_brands is True
+        assert cmd.restricted_brand_ids == [9]
+
+
+class TestUpdate:
+    def test_builds_update_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.update.return_value = sentinel.form
+
+        result = service.update(7, name="Updated", active=False)
+
+        assert client.update.call_args.kwargs["ticket_form_id"] == 7
+        cmd = client.update.call_args.kwargs["entity"]
+        assert isinstance(cmd, UpdateTicketFormCmd)
+        assert cmd.name == "Updated"
+        assert cmd.active is False
+        assert result is sentinel.form
+
+    def test_empty_fields_yields_blank_cmd(self):
+        service, client = _make_service()
+        service.update(1)
+        cmd = client.update.call_args.kwargs["entity"]
+        assert cmd.name is None
+        assert cmd.ticket_field_ids is None
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize(
+        "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+    )
+    def test_create_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.create.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.create(name="n", ticket_field_ids=[1])
+
+    @pytest.mark.parametrize(
+        "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+    )
+    def test_update_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.update.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.update(1)
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_all_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.list.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list_all()


### PR DESCRIPTION
## Summary
- Introduce `CreateTicketFormCmd` / `UpdateTicketFormCmd` (frozen slots dataclasses)
- Mapper emits every Zendesk `ticket_form` field (name, display_name, ticket_field_ids, end_user_visible, position, active, default, in_all_brands, restricted_brand_ids, end_user_conditions, agent_conditions) while preserving false booleans and skipping unset optionals
- Extend `TicketFormApiClient` with `create`, `update`, `delete`, `clone`, `reorder`
- Migrate `TicketFormsService` to `**fields` kwargs ergonomics and surface the new endpoints

## Test plan
- [x] Unit: mapper, client (list/get/create/update/delete/clone/reorder/errors), service (delegation/create/update/errors), domain logical_key
- [x] \`pytest tests/unit\` — 1895 passed
- [x] Coverage — 160/160 stmts (100%) across cmds/mapper/client/service/domain
- [ ] Integration (live tenant): \`tests/integration/ticketing/test_ticket_form.py\`

Refs #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)