### PR TITLE
feat(ticketing): add user fields CUD, reorder, option helpers

### DIFF
--- a/libzapi/application/commands/ticketing/user_field_cmds.py
+++ b/libzapi/application/commands/ticketing/user_field_cmds.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, TypeAlias
+
+
+@dataclass(frozen=True, slots=True)
+class CreateUserFieldCmd:
+    key: str
+    type: str
+    title: str
+    description: str | None = None
+    active: bool | None = None
+    position: int | None = None
+    regexp_for_validation: str | None = None
+    tag: str | None = None
+    relationship_target_type: str | None = None
+    relationship_filter: dict[str, Any] | None = None
+    custom_field_options: Iterable[dict[str, Any]] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateUserFieldCmd:
+    key: str | None = None
+    title: str | None = None
+    description: str | None = None
+    active: bool | None = None
+    position: int | None = None
+    regexp_for_validation: str | None = None
+    tag: str | None = None
+    relationship_target_type: str | None = None
+    relationship_filter: dict[str, Any] | None = None
+    custom_field_options: Iterable[dict[str, Any]] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UserFieldOptionCmd:
+    name: str
+    value: str
+    id: int | None = None
+
+
+UserFieldCmd: TypeAlias = CreateUserFieldCmd | UpdateUserFieldCmd

--- a/libzapi/application/services/ticketing/user_fields_service.py
+++ b/libzapi/application/services/ticketing/user_fields_service.py
@@ -1,7 +1,16 @@
+from __future__ import annotations
+
 from typing import Iterable
 
-from libzapi.domain.models.ticketing.user_field import UserField, CustomFieldOption
-from libzapi.infrastructure.api_clients.ticketing.user_field_api_client import UserFieldApiClient
+from libzapi.application.commands.ticketing.user_field_cmds import (
+    CreateUserFieldCmd,
+    UpdateUserFieldCmd,
+    UserFieldOptionCmd,
+)
+from libzapi.domain.models.ticketing.user_field import CustomFieldOption, UserField
+from libzapi.infrastructure.api_clients.ticketing.user_field_api_client import (
+    UserFieldApiClient,
+)
 
 
 class UserFieldsService:
@@ -19,5 +28,44 @@ class UserFieldsService:
     def get_by_id(self, user_field_id: int) -> UserField:
         return self._client.get(user_field_id=user_field_id)
 
-    def get_option_by_id(self, user_field_id: int, user_field_option_id: int) -> CustomFieldOption:
-        return self._client.get_option(user_field_id=user_field_id, user_field_option_id=user_field_option_id)
+    def get_option_by_id(
+        self, user_field_id: int, user_field_option_id: int
+    ) -> CustomFieldOption:
+        return self._client.get_option(
+            user_field_id=user_field_id,
+            user_field_option_id=user_field_option_id,
+        )
+
+    def create(self, **fields) -> UserField:
+        return self._client.create(entity=CreateUserFieldCmd(**fields))
+
+    def update(self, user_field_id: int, **fields) -> UserField:
+        return self._client.update(
+            user_field_id=user_field_id, entity=UpdateUserFieldCmd(**fields)
+        )
+
+    def delete(self, user_field_id: int) -> None:
+        self._client.delete(user_field_id=user_field_id)
+
+    def reorder(self, user_field_ids: Iterable[int]) -> None:
+        self._client.reorder(user_field_ids=user_field_ids)
+
+    def upsert_option(
+        self,
+        user_field_id: int,
+        name: str,
+        value: str,
+        id: int | None = None,
+    ) -> CustomFieldOption:
+        return self._client.upsert_option(
+            user_field_id=user_field_id,
+            option=UserFieldOptionCmd(name=name, value=value, id=id),
+        )
+
+    def delete_option(
+        self, user_field_id: int, user_field_option_id: int
+    ) -> None:
+        self._client.delete_option(
+            user_field_id=user_field_id,
+            user_field_option_id=user_field_option_id,
+        )

--- a/libzapi/infrastructure/api_clients/ticketing/user_field_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/user_field_api_client.py
@@ -1,20 +1,30 @@
 from __future__ import annotations
-from typing import Iterable
 
+from typing import Iterable, Iterator
 
+from libzapi.application.commands.ticketing.user_field_cmds import (
+    CreateUserFieldCmd,
+    UpdateUserFieldCmd,
+    UserFieldOptionCmd,
+)
+from libzapi.domain.models.ticketing.user_field import CustomFieldOption, UserField
 from libzapi.infrastructure.http.client import HttpClient
 from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.mappers.ticketing.user_field_mapper import (
+    option_to_payload,
+    to_payload_create,
+    to_payload_update,
+)
 from libzapi.infrastructure.serialization.parse import to_domain
-from libzapi.domain.models.ticketing.user_field import UserField, CustomFieldOption
 
 
 class UserFieldApiClient:
-    """HTTP adapter for Zendesk User Field with shared cursor pagination."""
+    """HTTP adapter for Zendesk User Fields with shared cursor pagination."""
 
     def __init__(self, http: HttpClient) -> None:
         self._http = http
 
-    def list_all(self) -> Iterable[UserField]:
+    def list_all(self) -> Iterator[UserField]:
         for obj in yield_items(
             get_json=self._http.get,
             first_path="/api/v2/user_fields",
@@ -23,10 +33,10 @@ class UserFieldApiClient:
         ):
             yield to_domain(data=obj, cls=UserField)
 
-    def list_options(self, user_field_id: int) -> Iterable[CustomFieldOption]:
+    def list_options(self, user_field_id: int) -> Iterator[CustomFieldOption]:
         for obj in yield_items(
             get_json=self._http.get,
-            first_path=f"/api/v2/user_fields/{user_field_id}/options",
+            first_path=f"/api/v2/user_fields/{int(user_field_id)}/options",
             base_url=self._http.base_url,
             items_key="custom_field_options",
         ):
@@ -36,6 +46,45 @@ class UserFieldApiClient:
         data = self._http.get(f"/api/v2/user_fields/{int(user_field_id)}")
         return to_domain(data=data["user_field"], cls=UserField)
 
-    def get_option(self, user_field_id: int, user_field_option_id: int) -> CustomFieldOption:
-        data = self._http.get(f"/api/v2/user_fields/{int(user_field_id)}/options/{int(user_field_option_id)}")
+    def get_option(
+        self, user_field_id: int, user_field_option_id: int
+    ) -> CustomFieldOption:
+        data = self._http.get(
+            f"/api/v2/user_fields/{int(user_field_id)}/options/{int(user_field_option_id)}"
+        )
         return to_domain(data=data["custom_field_option"], cls=CustomFieldOption)
+
+    def create(self, entity: CreateUserFieldCmd) -> UserField:
+        payload = to_payload_create(entity)
+        data = self._http.post("/api/v2/user_fields", payload)
+        return to_domain(data=data["user_field"], cls=UserField)
+
+    def update(self, user_field_id: int, entity: UpdateUserFieldCmd) -> UserField:
+        payload = to_payload_update(entity)
+        data = self._http.put(
+            f"/api/v2/user_fields/{int(user_field_id)}", payload
+        )
+        return to_domain(data=data["user_field"], cls=UserField)
+
+    def delete(self, user_field_id: int) -> None:
+        self._http.delete(f"/api/v2/user_fields/{int(user_field_id)}")
+
+    def reorder(self, user_field_ids: Iterable[int]) -> None:
+        payload = {"user_field_ids": [int(i) for i in user_field_ids]}
+        self._http.put("/api/v2/user_fields/reorder", payload)
+
+    def upsert_option(
+        self, user_field_id: int, option: UserFieldOptionCmd
+    ) -> CustomFieldOption:
+        payload = option_to_payload(option)
+        data = self._http.post(
+            f"/api/v2/user_fields/{int(user_field_id)}/options", payload
+        )
+        return to_domain(data=data["custom_field_option"], cls=CustomFieldOption)
+
+    def delete_option(
+        self, user_field_id: int, user_field_option_id: int
+    ) -> None:
+        self._http.delete(
+            f"/api/v2/user_fields/{int(user_field_id)}/options/{int(user_field_option_id)}"
+        )

--- a/libzapi/infrastructure/mappers/ticketing/user_field_mapper.py
+++ b/libzapi/infrastructure/mappers/ticketing/user_field_mapper.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from libzapi.application.commands.ticketing.user_field_cmds import (
+    CreateUserFieldCmd,
+    UpdateUserFieldCmd,
+    UserFieldOptionCmd,
+)
+
+
+def _add_optionals(body: dict, cmd: CreateUserFieldCmd | UpdateUserFieldCmd) -> None:
+    if cmd.description is not None:
+        body["description"] = cmd.description
+    if cmd.active is not None:
+        body["active"] = cmd.active
+    if cmd.position is not None:
+        body["position"] = cmd.position
+    if cmd.regexp_for_validation is not None:
+        body["regexp_for_validation"] = cmd.regexp_for_validation
+    if cmd.tag is not None:
+        body["tag"] = cmd.tag
+    if cmd.relationship_target_type is not None:
+        body["relationship_target_type"] = cmd.relationship_target_type
+    if cmd.relationship_filter is not None:
+        body["relationship_filter"] = cmd.relationship_filter
+    if cmd.custom_field_options is not None:
+        body["custom_field_options"] = list(cmd.custom_field_options)
+
+
+def to_payload_create(cmd: CreateUserFieldCmd) -> dict:
+    body: dict = {"key": cmd.key, "type": cmd.type, "title": cmd.title}
+    _add_optionals(body, cmd)
+    return {"user_field": body}
+
+
+def to_payload_update(cmd: UpdateUserFieldCmd) -> dict:
+    body: dict = {}
+    if cmd.key is not None:
+        body["key"] = cmd.key
+    if cmd.title is not None:
+        body["title"] = cmd.title
+    _add_optionals(body, cmd)
+    return {"user_field": body}
+
+
+def option_to_payload(cmd: UserFieldOptionCmd) -> dict:
+    body: dict = {"name": cmd.name, "value": cmd.value}
+    if cmd.id is not None:
+        body["id"] = cmd.id
+    return {"custom_field_option": body}

--- a/tests/integration/ticketing/test_user_field.py
+++ b/tests/integration/ticketing/test_user_field.py
@@ -1,8 +1,76 @@
+import itertools
+import uuid
+
 from libzapi import Ticketing
 
 
+def _unique() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+def _create_field(ticketing: Ticketing, **overrides):
+    suffix = _unique()
+    defaults = dict(
+        key=f"libzapi_{suffix}",
+        type="text",
+        title=f"libzapi field {suffix}",
+    )
+    defaults.update(overrides)
+    return ticketing.user_fields.create(**defaults)
+
+
 def test_list_and_get_user_fields(ticketing: Ticketing):
-    objs = list(ticketing.user_fields.list_all())
+    objs = list(itertools.islice(ticketing.user_fields.list_all(), 20))
     assert len(objs) > 0
     obj = ticketing.user_fields.get_by_id(objs[0].id)
     assert obj.key == objs[0].key
+
+
+def test_create_update_delete_field(ticketing: Ticketing):
+    field = _create_field(ticketing, description="created by libzapi")
+    assert field.id > 0
+    try:
+        updated = ticketing.user_fields.update(
+            field.id, description="updated by libzapi", active=False
+        )
+        assert updated.description == "updated by libzapi"
+        assert updated.active is False
+    finally:
+        ticketing.user_fields.delete(field.id)
+
+
+def test_dropdown_options_lifecycle(ticketing: Ticketing):
+    field = _create_field(
+        ticketing,
+        type="dropdown",
+        custom_field_options=[
+            {"name": "Alpha", "value": f"alpha_{_unique()}"},
+        ],
+    )
+    try:
+        options = list(ticketing.user_fields.list_options(field.id))
+        assert len(options) >= 1
+
+        created = ticketing.user_fields.upsert_option(
+            user_field_id=field.id,
+            name="Beta",
+            value=f"beta_{_unique()}",
+        )
+        assert created.id
+
+        fetched = ticketing.user_fields.get_option_by_id(
+            user_field_id=field.id, user_field_option_id=created.id
+        )
+        assert fetched.id == created.id
+
+        ticketing.user_fields.delete_option(
+            user_field_id=field.id, user_field_option_id=created.id
+        )
+    finally:
+        ticketing.user_fields.delete(field.id)
+
+
+def test_reorder_does_not_raise(ticketing: Ticketing):
+    fields = list(itertools.islice(ticketing.user_fields.list_all(), 5))
+    ids = [f.id for f in fields]
+    ticketing.user_fields.reorder(ids)

--- a/tests/unit/ticketing/test_user_field.py
+++ b/tests/unit/ticketing/test_user_field.py
@@ -55,6 +55,29 @@ def test_user_field_api_client_get_option(mocker):
     https.get.assert_called_with("/api/v2/user_fields/44/options/55")
 
 
+def test_user_field_logical_key_normalises_key():
+    from datetime import datetime
+
+    from libzapi.domain.models.ticketing.user_field import UserField
+
+    field = UserField(
+        id=1,
+        url="https://x",
+        type="text",
+        key="Account Region",
+        title="Region",
+        description="",
+        raw_description="",
+        position=1,
+        active=True,
+        system=False,
+        regexp_for_validation=None,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    assert field.logical_key.as_str() == "user_field:account_region"
+
+
 @pytest.mark.parametrize(
     "error_cls",
     [

--- a/tests/unit/ticketing/test_user_field_client.py
+++ b/tests/unit/ticketing/test_user_field_client.py
@@ -1,0 +1,138 @@
+import pytest
+
+from libzapi.application.commands.ticketing.user_field_cmds import (
+    CreateUserFieldCmd,
+    UpdateUserFieldCmd,
+    UserFieldOptionCmd,
+)
+from libzapi.infrastructure.api_clients.ticketing import UserFieldApiClient
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.user_field_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Listing / pagination
+# ---------------------------------------------------------------------------
+
+
+def test_list_all_yields_items(http, domain):
+    http.get.return_value = {
+        "user_fields": [{"id": 1}, {"id": 2}],
+        "meta": {"has_more": False},
+        "links": {"next": None},
+    }
+    client = UserFieldApiClient(http)
+    result = list(client.list_all())
+    assert len(result) == 2
+    assert result[0]["id"] == 1
+
+
+def test_list_options_yields_items(http, domain):
+    http.get.return_value = {
+        "custom_field_options": [{"id": 1}, {"id": 2}],
+        "meta": {"has_more": False},
+        "links": {"next": None},
+    }
+    client = UserFieldApiClient(http)
+    result = list(client.list_options(user_field_id=5))
+    http.get.assert_called_with("/api/v2/user_fields/5/options")
+    assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# create / update / delete / reorder
+# ---------------------------------------------------------------------------
+
+
+def test_create_posts_payload(http, domain):
+    http.post.return_value = {"user_field": {"id": 1, "key": "region"}}
+    client = UserFieldApiClient(http)
+    result = client.create(
+        CreateUserFieldCmd(key="region", type="text", title="Region")
+    )
+    http.post.assert_called_with(
+        "/api/v2/user_fields",
+        {"user_field": {"key": "region", "type": "text", "title": "Region"}},
+    )
+    assert result["key"] == "region"
+
+
+def test_update_puts_payload(http, domain):
+    http.put.return_value = {"user_field": {"id": 1, "active": False}}
+    client = UserFieldApiClient(http)
+    client.update(user_field_id=1, entity=UpdateUserFieldCmd(active=False))
+    http.put.assert_called_with(
+        "/api/v2/user_fields/1", {"user_field": {"active": False}}
+    )
+
+
+def test_delete_calls_delete(http):
+    client = UserFieldApiClient(http)
+    client.delete(user_field_id=7)
+    http.delete.assert_called_with("/api/v2/user_fields/7")
+
+
+def test_reorder_puts_ids(http):
+    client = UserFieldApiClient(http)
+    client.reorder(user_field_ids=[3, 1, 2])
+    http.put.assert_called_with(
+        "/api/v2/user_fields/reorder", {"user_field_ids": [3, 1, 2]}
+    )
+
+
+def test_reorder_converts_iterable(http):
+    client = UserFieldApiClient(http)
+    client.reorder(user_field_ids=iter([3, 1]))
+    http.put.assert_called_with(
+        "/api/v2/user_fields/reorder", {"user_field_ids": [3, 1]}
+    )
+
+
+# ---------------------------------------------------------------------------
+# options
+# ---------------------------------------------------------------------------
+
+
+def test_upsert_option_posts_payload(http, domain):
+    http.post.return_value = {"custom_field_option": {"id": 9, "name": "A"}}
+    client = UserFieldApiClient(http)
+    result = client.upsert_option(
+        user_field_id=5, option=UserFieldOptionCmd(name="A", value="a")
+    )
+    http.post.assert_called_with(
+        "/api/v2/user_fields/5/options",
+        {"custom_field_option": {"name": "A", "value": "a"}},
+    )
+    assert result["id"] == 9
+
+
+def test_upsert_option_with_id_posts_payload(http, domain):
+    http.post.return_value = {"custom_field_option": {"id": 9}}
+    client = UserFieldApiClient(http)
+    client.upsert_option(
+        user_field_id=5,
+        option=UserFieldOptionCmd(name="A", value="a", id=9),
+    )
+    http.post.assert_called_with(
+        "/api/v2/user_fields/5/options",
+        {"custom_field_option": {"name": "A", "value": "a", "id": 9}},
+    )
+
+
+def test_delete_option_calls_delete(http):
+    client = UserFieldApiClient(http)
+    client.delete_option(user_field_id=5, user_field_option_id=7)
+    http.delete.assert_called_with("/api/v2/user_fields/5/options/7")

--- a/tests/unit/ticketing/test_user_field_mapper.py
+++ b/tests/unit/ticketing/test_user_field_mapper.py
@@ -1,0 +1,145 @@
+from libzapi.application.commands.ticketing.user_field_cmds import (
+    CreateUserFieldCmd,
+    UpdateUserFieldCmd,
+    UserFieldOptionCmd,
+)
+from libzapi.infrastructure.mappers.ticketing.user_field_mapper import (
+    option_to_payload,
+    to_payload_create,
+    to_payload_update,
+)
+
+
+# ---------------------------------------------------------------------------
+# to_payload_create
+# ---------------------------------------------------------------------------
+
+
+def test_create_minimal_payload_only_includes_required():
+    payload = to_payload_create(
+        CreateUserFieldCmd(key="region", type="text", title="Region")
+    )
+    assert payload == {
+        "user_field": {"key": "region", "type": "text", "title": "Region"}
+    }
+
+
+def test_create_includes_all_optional_fields():
+    cmd = CreateUserFieldCmd(
+        key="region",
+        type="tagger",
+        title="Region",
+        description="desc",
+        active=True,
+        position=3,
+        regexp_for_validation=r"\d+",
+        tag="r",
+        relationship_target_type="zen:user",
+        relationship_filter={"all": []},
+        custom_field_options=[{"name": "A", "value": "a"}],
+    )
+
+    body = to_payload_create(cmd)["user_field"]
+
+    assert body["key"] == "region"
+    assert body["type"] == "tagger"
+    assert body["title"] == "Region"
+    assert body["description"] == "desc"
+    assert body["active"] is True
+    assert body["position"] == 3
+    assert body["regexp_for_validation"] == r"\d+"
+    assert body["tag"] == "r"
+    assert body["relationship_target_type"] == "zen:user"
+    assert body["relationship_filter"] == {"all": []}
+    assert body["custom_field_options"] == [{"name": "A", "value": "a"}]
+
+
+def test_create_preserves_false_booleans():
+    body = to_payload_create(
+        CreateUserFieldCmd(key="k", type="text", title="T", active=False)
+    )["user_field"]
+    assert body["active"] is False
+
+
+def test_create_skips_none_optional_fields():
+    body = to_payload_create(
+        CreateUserFieldCmd(key="k", type="text", title="T")
+    )["user_field"]
+    assert set(body.keys()) == {"key", "type", "title"}
+
+
+def test_create_converts_options_iterable_to_list():
+    opts = [{"name": "A", "value": "a"}]
+    body = to_payload_create(
+        CreateUserFieldCmd(
+            key="k", type="tagger", title="T", custom_field_options=iter(opts)
+        )
+    )["user_field"]
+    assert body["custom_field_options"] == opts
+
+
+# ---------------------------------------------------------------------------
+# to_payload_update
+# ---------------------------------------------------------------------------
+
+
+def test_update_empty_cmd_returns_empty_patch():
+    assert to_payload_update(UpdateUserFieldCmd()) == {"user_field": {}}
+
+
+def test_update_includes_all_fields():
+    cmd = UpdateUserFieldCmd(
+        key="region",
+        title="Region",
+        description="d",
+        active=True,
+        position=1,
+        regexp_for_validation=r"\d+",
+        tag="r",
+        relationship_target_type="zen:user",
+        relationship_filter={"all": []},
+        custom_field_options=[{"name": "A", "value": "a"}],
+    )
+    body = to_payload_update(cmd)["user_field"]
+    assert body == {
+        "key": "region",
+        "title": "Region",
+        "description": "d",
+        "active": True,
+        "position": 1,
+        "regexp_for_validation": r"\d+",
+        "tag": "r",
+        "relationship_target_type": "zen:user",
+        "relationship_filter": {"all": []},
+        "custom_field_options": [{"name": "A", "value": "a"}],
+    }
+
+
+def test_update_preserves_false_booleans():
+    body = to_payload_update(UpdateUserFieldCmd(active=False))["user_field"]
+    assert body == {"active": False}
+
+
+def test_update_converts_options_iterable_to_list():
+    opts = [{"name": "A", "value": "a"}]
+    body = to_payload_update(
+        UpdateUserFieldCmd(custom_field_options=iter(opts))
+    )["user_field"]
+    assert body["custom_field_options"] == opts
+
+
+# ---------------------------------------------------------------------------
+# option_to_payload
+# ---------------------------------------------------------------------------
+
+
+def test_option_to_payload_without_id():
+    payload = option_to_payload(UserFieldOptionCmd(name="A", value="a"))
+    assert payload == {"custom_field_option": {"name": "A", "value": "a"}}
+
+
+def test_option_to_payload_with_id():
+    payload = option_to_payload(UserFieldOptionCmd(name="A", value="a", id=7))
+    assert payload == {
+        "custom_field_option": {"name": "A", "value": "a", "id": 7}
+    }

--- a/tests/unit/ticketing/test_user_field_service.py
+++ b/tests/unit/ticketing/test_user_field_service.py
@@ -1,0 +1,154 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.commands.ticketing.user_field_cmds import (
+    CreateUserFieldCmd,
+    UpdateUserFieldCmd,
+    UserFieldOptionCmd,
+)
+from libzapi.application.services.ticketing.user_fields_service import (
+    UserFieldsService,
+)
+from libzapi.domain.errors import (
+    NotFound,
+    RateLimited,
+    Unauthorized,
+    UnprocessableEntity,
+)
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return UserFieldsService(client), client
+
+
+class TestDelegation:
+    def test_list_all_delegates(self):
+        service, client = _make_service()
+        client.list_all.return_value = sentinel.fields
+        assert service.list_all() is sentinel.fields
+
+    def test_list_options_delegates(self):
+        service, client = _make_service()
+        client.list_options.return_value = sentinel.options
+        assert service.list_options(5) is sentinel.options
+        client.list_options.assert_called_once_with(user_field_id=5)
+
+    def test_get_by_id_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.field
+        assert service.get_by_id(5) is sentinel.field
+        client.get.assert_called_once_with(user_field_id=5)
+
+    def test_get_option_by_id_delegates(self):
+        service, client = _make_service()
+        client.get_option.return_value = sentinel.option
+        assert (
+            service.get_option_by_id(user_field_id=5, user_field_option_id=7)
+            is sentinel.option
+        )
+        client.get_option.assert_called_once_with(
+            user_field_id=5, user_field_option_id=7
+        )
+
+    def test_delete_delegates(self):
+        service, client = _make_service()
+        service.delete(5)
+        client.delete.assert_called_once_with(user_field_id=5)
+
+    def test_reorder_delegates(self):
+        service, client = _make_service()
+        service.reorder([3, 1, 2])
+        client.reorder.assert_called_once_with(user_field_ids=[3, 1, 2])
+
+    def test_delete_option_delegates(self):
+        service, client = _make_service()
+        service.delete_option(user_field_id=5, user_field_option_id=7)
+        client.delete_option.assert_called_once_with(
+            user_field_id=5, user_field_option_id=7
+        )
+
+
+class TestCreate:
+    def test_builds_create_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.create.return_value = sentinel.field
+
+        result = service.create(key="region", type="text", title="Region")
+
+        cmd = client.create.call_args.kwargs["entity"]
+        assert isinstance(cmd, CreateUserFieldCmd)
+        assert cmd.key == "region"
+        assert cmd.type == "text"
+        assert cmd.title == "Region"
+        assert result is sentinel.field
+
+
+class TestUpdate:
+    def test_builds_update_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.update.return_value = sentinel.field
+
+        result = service.update(7, title="New", active=False)
+
+        assert client.update.call_args.kwargs["user_field_id"] == 7
+        cmd = client.update.call_args.kwargs["entity"]
+        assert isinstance(cmd, UpdateUserFieldCmd)
+        assert cmd.title == "New"
+        assert cmd.active is False
+        assert result is sentinel.field
+
+    def test_empty_fields_yields_blank_cmd(self):
+        service, client = _make_service()
+        service.update(1)
+        cmd = client.update.call_args.kwargs["entity"]
+        assert cmd.title is None
+        assert cmd.active is None
+
+
+class TestUpsertOption:
+    def test_builds_option_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.upsert_option.return_value = sentinel.option
+
+        result = service.upsert_option(user_field_id=5, name="A", value="a")
+
+        assert result is sentinel.option
+        cmd = client.upsert_option.call_args.kwargs["option"]
+        assert isinstance(cmd, UserFieldOptionCmd)
+        assert cmd.name == "A"
+        assert cmd.value == "a"
+        assert cmd.id is None
+
+    def test_passes_id(self):
+        service, client = _make_service()
+        service.upsert_option(user_field_id=5, name="A", value="a", id=9)
+        cmd = client.upsert_option.call_args.kwargs["option"]
+        assert cmd.id == 9
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize(
+        "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+    )
+    def test_create_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.create.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.create(key="k", type="text", title="T")
+
+    @pytest.mark.parametrize(
+        "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+    )
+    def test_update_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.update.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.update(1)
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_all_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.list_all.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list_all()


### PR DESCRIPTION
## Summary
- Introduce `CreateUserFieldCmd` / `UpdateUserFieldCmd` / `UserFieldOptionCmd`
- Mapper covers the full Zendesk user_field payload (description, active, position, regexp_for_validation, tag, relationship_target_type, relationship_filter, custom_field_options) preserving false booleans and skipping unset optionals
- Extend `UserFieldApiClient` with create/update/delete, reorder, upsert_option, delete_option
- Migrate `UserFieldsService` to `**fields` kwargs ergonomics and surface the new endpoints

## Test plan
- [x] Unit: mapper, client (list/list_options/create/update/delete/reorder/options/errors), service (delegation/create/update/upsert/errors), domain logical_key
- [x] \`pytest tests/unit\` — 1898 passed
- [x] Coverage — 174/174 stmts (100%) across cmds/mapper/client/service/domain
- [ ] Integration (live tenant): \`tests/integration/ticketing/test_user_field.py\`

Refs #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)