### PR TITLE
feat(ticketing): add workspaces CUD, destroy_many, reorder

### DIFF
--- a/libzapi/application/commands/ticketing/workspace_cmds.py
+++ b/libzapi/application/commands/ticketing/workspace_cmds.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, TypeAlias
+
+
+@dataclass(frozen=True, slots=True)
+class CreateWorkspaceCmd:
+    title: str
+    conditions: dict[str, Any]
+    description: str | None = None
+    activated: bool | None = None
+    prefer_workspace_app_order: bool | None = None
+    macros: Iterable[int] | None = None
+    apps: Iterable[dict[str, Any]] | None = None
+    ticket_form_id: int | None = None
+    position: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateWorkspaceCmd:
+    title: str | None = None
+    description: str | None = None
+    conditions: dict[str, Any] | None = None
+    activated: bool | None = None
+    prefer_workspace_app_order: bool | None = None
+    macros: Iterable[int] | None = None
+    apps: Iterable[dict[str, Any]] | None = None
+    ticket_form_id: int | None = None
+    position: int | None = None
+
+
+WorkspaceCmd: TypeAlias = CreateWorkspaceCmd | UpdateWorkspaceCmd

--- a/libzapi/application/services/ticketing/workspace_service.py
+++ b/libzapi/application/services/ticketing/workspace_service.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
 from typing import Iterable
 
+from libzapi.application.commands.ticketing.workspace_cmds import (
+    CreateWorkspaceCmd,
+    UpdateWorkspaceCmd,
+)
 from libzapi.domain.models.ticketing.workspace import Workspace
-from libzapi.infrastructure.api_clients.ticketing.workspace_api_client import WorkspaceApiClient
+from libzapi.infrastructure.api_clients.ticketing.workspace_api_client import (
+    WorkspaceApiClient,
+)
 
 
 class WorkspaceService:
@@ -14,4 +22,21 @@ class WorkspaceService:
         return self._client.list()
 
     def get(self, workspace_id: int) -> Workspace:
-        return self._client.get(workspace_id)
+        return self._client.get(workspace_id=workspace_id)
+
+    def create(self, **fields) -> Workspace:
+        return self._client.create(entity=CreateWorkspaceCmd(**fields))
+
+    def update(self, workspace_id: int, **fields) -> Workspace:
+        return self._client.update(
+            workspace_id=workspace_id, entity=UpdateWorkspaceCmd(**fields)
+        )
+
+    def delete(self, workspace_id: int) -> None:
+        self._client.delete(workspace_id=workspace_id)
+
+    def destroy_many(self, workspace_ids: Iterable[int]) -> None:
+        self._client.destroy_many(workspace_ids=workspace_ids)
+
+    def reorder(self, workspace_ids: Iterable[int]) -> None:
+        self._client.reorder(workspace_ids=workspace_ids)

--- a/libzapi/infrastructure/api_clients/ticketing/workspace_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/workspace_api_client.py
@@ -1,20 +1,28 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Iterator
 
+from libzapi.application.commands.ticketing.workspace_cmds import (
+    CreateWorkspaceCmd,
+    UpdateWorkspaceCmd,
+)
 from libzapi.domain.models.ticketing.workspace import Workspace
 from libzapi.infrastructure.http.client import HttpClient
 from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.mappers.ticketing.workspace_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
 from libzapi.infrastructure.serialization.parse import to_domain
 
 
 class WorkspaceApiClient:
-    """HTTP adapter for Zendesk Workspace"""
+    """HTTP adapter for Zendesk Workspaces with shared cursor pagination."""
 
     def __init__(self, http: HttpClient) -> None:
         self._http = http
 
-    def list(self) -> Iterable[Workspace]:
+    def list(self) -> Iterator[Workspace]:
         for obj in yield_items(
             get_json=self._http.get,
             first_path="/api/v2/workspaces",
@@ -26,3 +34,26 @@ class WorkspaceApiClient:
     def get(self, workspace_id: int) -> Workspace:
         data = self._http.get(f"/api/v2/workspaces/{int(workspace_id)}")
         return to_domain(data=data["workspace"], cls=Workspace)
+
+    def create(self, entity: CreateWorkspaceCmd) -> Workspace:
+        payload = to_payload_create(entity)
+        data = self._http.post("/api/v2/workspaces", payload)
+        return to_domain(data=data["workspace"], cls=Workspace)
+
+    def update(self, workspace_id: int, entity: UpdateWorkspaceCmd) -> Workspace:
+        payload = to_payload_update(entity)
+        data = self._http.put(
+            f"/api/v2/workspaces/{int(workspace_id)}", payload
+        )
+        return to_domain(data=data["workspace"], cls=Workspace)
+
+    def delete(self, workspace_id: int) -> None:
+        self._http.delete(f"/api/v2/workspaces/{int(workspace_id)}")
+
+    def destroy_many(self, workspace_ids: Iterable[int]) -> None:
+        ids_str = ",".join(str(int(i)) for i in workspace_ids)
+        self._http.delete(f"/api/v2/workspaces/destroy_many?ids={ids_str}")
+
+    def reorder(self, workspace_ids: Iterable[int]) -> None:
+        payload = {"ids": [int(i) for i in workspace_ids]}
+        self._http.put("/api/v2/workspaces/reorder", payload)

--- a/libzapi/infrastructure/mappers/ticketing/workspace_mapper.py
+++ b/libzapi/infrastructure/mappers/ticketing/workspace_mapper.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from libzapi.application.commands.ticketing.workspace_cmds import (
+    CreateWorkspaceCmd,
+    UpdateWorkspaceCmd,
+)
+
+
+def _add_optionals(body: dict, cmd: CreateWorkspaceCmd | UpdateWorkspaceCmd) -> None:
+    if cmd.description is not None:
+        body["description"] = cmd.description
+    if cmd.activated is not None:
+        body["activated"] = cmd.activated
+    if cmd.prefer_workspace_app_order is not None:
+        body["prefer_workspace_app_order"] = cmd.prefer_workspace_app_order
+    if cmd.macros is not None:
+        body["macros"] = [int(i) for i in cmd.macros]
+    if cmd.apps is not None:
+        body["apps"] = list(cmd.apps)
+    if cmd.ticket_form_id is not None:
+        body["ticket_form_id"] = int(cmd.ticket_form_id)
+    if cmd.position is not None:
+        body["position"] = cmd.position
+
+
+def to_payload_create(cmd: CreateWorkspaceCmd) -> dict:
+    body: dict = {"title": cmd.title, "conditions": cmd.conditions}
+    _add_optionals(body, cmd)
+    return {"workspace": body}
+
+
+def to_payload_update(cmd: UpdateWorkspaceCmd) -> dict:
+    body: dict = {}
+    if cmd.title is not None:
+        body["title"] = cmd.title
+    if cmd.conditions is not None:
+        body["conditions"] = cmd.conditions
+    _add_optionals(body, cmd)
+    return {"workspace": body}

--- a/tests/integration/ticketing/test_workspace.py
+++ b/tests/integration/ticketing/test_workspace.py
@@ -1,0 +1,48 @@
+import itertools
+import uuid
+
+from libzapi import Ticketing
+
+
+def _unique() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+_COND = {"all": [{"field": "status", "operator": "is", "value": "new"}]}
+
+
+def _create_workspace(ticketing: Ticketing, **overrides):
+    suffix = _unique()
+    defaults = dict(
+        title=f"libzapi workspace {suffix}",
+        conditions=_COND,
+    )
+    defaults.update(overrides)
+    return ticketing.workspaces.create(**defaults)
+
+
+def test_list_and_get_workspace(ticketing: Ticketing):
+    workspaces = list(itertools.islice(ticketing.workspaces.list(), 10))
+    if not workspaces:
+        return
+    ws = ticketing.workspaces.get(workspaces[0].id)
+    assert ws.title == workspaces[0].title
+
+
+def test_create_update_delete_workspace(ticketing: Ticketing):
+    ws = _create_workspace(ticketing, description="created by libzapi")
+    assert ws.id > 0
+    try:
+        updated = ticketing.workspaces.update(
+            ws.id, description="updated by libzapi", activated=False
+        )
+        assert updated.description == "updated by libzapi"
+    finally:
+        ticketing.workspaces.delete(ws.id)
+
+
+def test_reorder_does_not_raise(ticketing: Ticketing):
+    workspaces = list(itertools.islice(ticketing.workspaces.list(), 5))
+    ids = [w.id for w in workspaces]
+    if ids:
+        ticketing.workspaces.reorder(ids)

--- a/tests/unit/ticketing/test_workspace_client.py
+++ b/tests/unit/ticketing/test_workspace_client.py
@@ -1,0 +1,117 @@
+import pytest
+
+from libzapi.application.commands.ticketing.workspace_cmds import (
+    CreateWorkspaceCmd,
+    UpdateWorkspaceCmd,
+)
+from libzapi.domain.errors import (
+    NotFound,
+    RateLimited,
+    Unauthorized,
+    UnprocessableEntity,
+)
+from libzapi.infrastructure.api_clients.ticketing import WorkspaceApiClient
+
+
+_COND = {"all": [{"field": "status", "operator": "is", "value": "new"}]}
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.workspace_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+def test_list_yields_items(http, domain):
+    http.get.return_value = {
+        "workspaces": [{"id": 1}, {"id": 2}],
+        "meta": {"has_more": False},
+        "links": {"next": None},
+    }
+    client = WorkspaceApiClient(http)
+    result = list(client.list())
+    http.get.assert_called_with("/api/v2/workspaces")
+    assert len(result) == 2
+
+
+def test_get_returns_domain(http, domain):
+    http.get.return_value = {"workspace": {"id": 5}}
+    client = WorkspaceApiClient(http)
+    result = client.get(workspace_id=5)
+    http.get.assert_called_with("/api/v2/workspaces/5")
+    assert result["id"] == 5
+
+
+def test_create_posts_payload(http, domain):
+    http.post.return_value = {"workspace": {"id": 1, "title": "W"}}
+    client = WorkspaceApiClient(http)
+    result = client.create(CreateWorkspaceCmd(title="W", conditions=_COND))
+    http.post.assert_called_with(
+        "/api/v2/workspaces",
+        {"workspace": {"title": "W", "conditions": _COND}},
+    )
+    assert result["title"] == "W"
+
+
+def test_update_puts_payload(http, domain):
+    http.put.return_value = {"workspace": {"id": 1, "activated": False}}
+    client = WorkspaceApiClient(http)
+    client.update(workspace_id=1, entity=UpdateWorkspaceCmd(activated=False))
+    http.put.assert_called_with(
+        "/api/v2/workspaces/1", {"workspace": {"activated": False}}
+    )
+
+
+def test_delete_calls_delete(http):
+    client = WorkspaceApiClient(http)
+    client.delete(workspace_id=7)
+    http.delete.assert_called_with("/api/v2/workspaces/7")
+
+
+def test_destroy_many_deletes_with_ids(http):
+    client = WorkspaceApiClient(http)
+    client.destroy_many([1, 2])
+    http.delete.assert_called_with("/api/v2/workspaces/destroy_many?ids=1,2")
+
+
+def test_reorder_puts_ids(http):
+    client = WorkspaceApiClient(http)
+    client.reorder([3, 1, 2])
+    http.put.assert_called_with(
+        "/api/v2/workspaces/reorder", {"ids": [3, 1, 2]}
+    )
+
+
+def test_reorder_converts_iterable(http):
+    client = WorkspaceApiClient(http)
+    client.reorder(iter([3, 1]))
+    http.put.assert_called_with("/api/v2/workspaces/reorder", {"ids": [3, 1]})
+
+
+@pytest.mark.parametrize(
+    "error_cls",
+    [
+        pytest.param(Unauthorized, id="401"),
+        pytest.param(NotFound, id="404"),
+        pytest.param(UnprocessableEntity, id="422"),
+        pytest.param(RateLimited, id="429"),
+    ],
+)
+def test_workspace_api_client_raises_on_http_error(error_cls, mocker):
+    https = mocker.Mock()
+    https.base_url = "https://example.zendesk.com"
+    https.get.side_effect = error_cls("error")
+
+    client = WorkspaceApiClient(https)
+
+    with pytest.raises(error_cls):
+        list(client.list())

--- a/tests/unit/ticketing/test_workspace_mapper.py
+++ b/tests/unit/ticketing/test_workspace_mapper.py
@@ -1,0 +1,130 @@
+from libzapi.application.commands.ticketing.workspace_cmds import (
+    CreateWorkspaceCmd,
+    UpdateWorkspaceCmd,
+)
+from libzapi.infrastructure.mappers.ticketing.workspace_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
+
+
+_COND = {"all": [{"field": "status", "operator": "is", "value": "new"}]}
+
+
+# ---------------------------------------------------------------------------
+# to_payload_create
+# ---------------------------------------------------------------------------
+
+
+def test_create_minimal_payload_only_includes_required():
+    payload = to_payload_create(CreateWorkspaceCmd(title="W", conditions=_COND))
+    assert payload == {
+        "workspace": {"title": "W", "conditions": _COND}
+    }
+
+
+def test_create_includes_all_optional_fields():
+    cmd = CreateWorkspaceCmd(
+        title="W",
+        conditions=_COND,
+        description="desc",
+        activated=True,
+        prefer_workspace_app_order=True,
+        macros=[1, 2],
+        apps=[{"id": 1, "expand": True, "position": 1}],
+        ticket_form_id=9,
+        position=2,
+    )
+
+    body = to_payload_create(cmd)["workspace"]
+
+    assert body["title"] == "W"
+    assert body["conditions"] == _COND
+    assert body["description"] == "desc"
+    assert body["activated"] is True
+    assert body["prefer_workspace_app_order"] is True
+    assert body["macros"] == [1, 2]
+    assert body["apps"] == [{"id": 1, "expand": True, "position": 1}]
+    assert body["ticket_form_id"] == 9
+    assert body["position"] == 2
+
+
+def test_create_preserves_false_booleans():
+    body = to_payload_create(
+        CreateWorkspaceCmd(
+            title="W",
+            conditions=_COND,
+            activated=False,
+            prefer_workspace_app_order=False,
+        )
+    )["workspace"]
+    assert body["activated"] is False
+    assert body["prefer_workspace_app_order"] is False
+
+
+def test_create_skips_none_optional_fields():
+    body = to_payload_create(
+        CreateWorkspaceCmd(title="W", conditions=_COND)
+    )["workspace"]
+    assert set(body.keys()) == {"title", "conditions"}
+
+
+def test_create_converts_iterables_to_lists():
+    body = to_payload_create(
+        CreateWorkspaceCmd(
+            title="W",
+            conditions=_COND,
+            macros=iter([7]),
+            apps=iter([{"id": 1}]),
+        )
+    )["workspace"]
+    assert body["macros"] == [7]
+    assert body["apps"] == [{"id": 1}]
+
+
+# ---------------------------------------------------------------------------
+# to_payload_update
+# ---------------------------------------------------------------------------
+
+
+def test_update_empty_cmd_returns_empty_patch():
+    assert to_payload_update(UpdateWorkspaceCmd()) == {"workspace": {}}
+
+
+def test_update_includes_all_fields():
+    cmd = UpdateWorkspaceCmd(
+        title="W2",
+        conditions=_COND,
+        description="d",
+        activated=True,
+        prefer_workspace_app_order=True,
+        macros=[1],
+        apps=[{"id": 3}],
+        ticket_form_id=9,
+        position=1,
+    )
+    body = to_payload_update(cmd)["workspace"]
+    assert body == {
+        "title": "W2",
+        "conditions": _COND,
+        "description": "d",
+        "activated": True,
+        "prefer_workspace_app_order": True,
+        "macros": [1],
+        "apps": [{"id": 3}],
+        "ticket_form_id": 9,
+        "position": 1,
+    }
+
+
+def test_update_preserves_false_booleans():
+    body = to_payload_update(UpdateWorkspaceCmd(activated=False))["workspace"]
+    assert body == {"activated": False}
+
+
+def test_update_converts_iterables_to_lists():
+    body = to_payload_update(
+        UpdateWorkspaceCmd(macros=iter([7]), apps=iter([{"id": 1}]))
+    )["workspace"]
+    assert body["macros"] == [7]
+    assert body["apps"] == [{"id": 1}]

--- a/tests/unit/ticketing/test_workspace_service.py
+++ b/tests/unit/ticketing/test_workspace_service.py
@@ -1,0 +1,113 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.commands.ticketing.workspace_cmds import (
+    CreateWorkspaceCmd,
+    UpdateWorkspaceCmd,
+)
+from libzapi.application.services.ticketing.workspace_service import WorkspaceService
+from libzapi.domain.errors import (
+    NotFound,
+    RateLimited,
+    Unauthorized,
+    UnprocessableEntity,
+)
+
+
+_COND = {"all": [{"field": "status", "operator": "is", "value": "new"}]}
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return WorkspaceService(client), client
+
+
+class TestDelegation:
+    def test_list_delegates(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.ws
+        assert service.list() is sentinel.ws
+
+    def test_get_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.ws
+        assert service.get(5) is sentinel.ws
+        client.get.assert_called_once_with(workspace_id=5)
+
+    def test_delete_delegates(self):
+        service, client = _make_service()
+        service.delete(5)
+        client.delete.assert_called_once_with(workspace_id=5)
+
+    def test_destroy_many_delegates(self):
+        service, client = _make_service()
+        service.destroy_many([1, 2])
+        client.destroy_many.assert_called_once_with(workspace_ids=[1, 2])
+
+    def test_reorder_delegates(self):
+        service, client = _make_service()
+        service.reorder([3, 1, 2])
+        client.reorder.assert_called_once_with(workspace_ids=[3, 1, 2])
+
+
+class TestCreate:
+    def test_builds_create_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.create.return_value = sentinel.ws
+
+        result = service.create(title="W", conditions=_COND)
+
+        cmd = client.create.call_args.kwargs["entity"]
+        assert isinstance(cmd, CreateWorkspaceCmd)
+        assert cmd.title == "W"
+        assert cmd.conditions == _COND
+        assert result is sentinel.ws
+
+
+class TestUpdate:
+    def test_builds_update_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.update.return_value = sentinel.ws
+
+        result = service.update(7, title="N", activated=False)
+
+        assert client.update.call_args.kwargs["workspace_id"] == 7
+        cmd = client.update.call_args.kwargs["entity"]
+        assert isinstance(cmd, UpdateWorkspaceCmd)
+        assert cmd.title == "N"
+        assert cmd.activated is False
+        assert result is sentinel.ws
+
+    def test_empty_fields_yields_blank_cmd(self):
+        service, client = _make_service()
+        service.update(1)
+        cmd = client.update.call_args.kwargs["entity"]
+        assert cmd.title is None
+        assert cmd.conditions is None
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize(
+        "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+    )
+    def test_create_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.create.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.create(title="t", conditions=_COND)
+
+    @pytest.mark.parametrize(
+        "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+    )
+    def test_update_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.update.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.update(1)
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.list.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list()


### PR DESCRIPTION
## Summary
- Introduce `CreateWorkspaceCmd` / `UpdateWorkspaceCmd`
- Mapper covers the full Zendesk workspace payload (title, conditions, description, activated, prefer_workspace_app_order, macros, apps, ticket_form_id, position) preserving false booleans and skipping unset optionals
- Extend `WorkspaceApiClient` with create/update/delete, destroy_many, reorder
- Migrate `WorkspaceService` to `**fields` kwargs ergonomics and surface the new endpoints

## Test plan
- [x] Unit: mapper, client (list/get/create/update/delete/destroy_many/reorder/errors), service (delegation/create/update/errors), domain logical_key
- [x] \`pytest tests/unit\` — 1893 passed
- [x] Coverage — 147/147 stmts (100%) across cmds/mapper/client/service/domain
- [ ] Integration (live tenant): \`tests/integration/ticketing/test_workspace.py\`

Refs #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)