### PR TITLE
feat(ticketing): schedules CUD + intervals + holidays

### DIFF
--- a/libzapi/application/commands/ticketing/schedule_cmds.py
+++ b/libzapi/application/commands/ticketing/schedule_cmds.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any, Iterable, TypeAlias
+
+
+@dataclass(frozen=True, slots=True)
+class CreateScheduleCmd:
+    name: str
+    time_zone: str
+    intervals: Iterable[dict[str, Any]] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateScheduleCmd:
+    name: str | None = None
+    time_zone: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateIntervalsCmd:
+    intervals: Iterable[dict[str, Any]]
+
+
+@dataclass(frozen=True, slots=True)
+class CreateHolidayCmd:
+    name: str
+    start_date: date | str
+    end_date: date | str
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateHolidayCmd:
+    name: str | None = None
+    start_date: date | str | None = None
+    end_date: date | str | None = None
+
+
+ScheduleCmd: TypeAlias = CreateScheduleCmd | UpdateScheduleCmd
+HolidayCmd: TypeAlias = CreateHolidayCmd | UpdateHolidayCmd

--- a/libzapi/application/services/ticketing/schedule_service.py
+++ b/libzapi/application/services/ticketing/schedule_service.py
@@ -1,7 +1,18 @@
+from __future__ import annotations
+
 from typing import Iterable
 
-from libzapi.domain.models.ticketing.schedule import Schedule, Holiday
-from libzapi.infrastructure.api_clients.ticketing.schedule_api_client import ScheduleApiClient
+from libzapi.application.commands.ticketing.schedule_cmds import (
+    CreateHolidayCmd,
+    CreateScheduleCmd,
+    UpdateHolidayCmd,
+    UpdateIntervalsCmd,
+    UpdateScheduleCmd,
+)
+from libzapi.domain.models.ticketing.schedule import Holiday, Schedule
+from libzapi.infrastructure.api_clients.ticketing.schedule_api_client import (
+    ScheduleApiClient,
+)
 
 
 class ScheduleService:
@@ -14,10 +25,48 @@ class ScheduleService:
         return self._client.list()
 
     def get_schedule(self, schedule_id: int) -> Schedule:
-        return self._client.get(schedule_id)
+        return self._client.get(schedule_id=schedule_id)
 
     def list_holidays(self, schedule_id: int) -> Iterable[Holiday]:
-        return self._client.list_holidays(schedule_id)
+        return self._client.list_holidays(schedule_id=schedule_id)
 
     def get_holiday(self, schedule_id: int, holiday_id: int) -> Holiday:
-        return self._client.get_holiday(schedule_id, holiday_id)
+        return self._client.get_holiday(
+            schedule_id=schedule_id, holiday_id=holiday_id
+        )
+
+    def create(self, **fields) -> Schedule:
+        return self._client.create(entity=CreateScheduleCmd(**fields))
+
+    def update(self, schedule_id: int, **fields) -> Schedule:
+        return self._client.update(
+            schedule_id=schedule_id, entity=UpdateScheduleCmd(**fields)
+        )
+
+    def delete(self, schedule_id: int) -> None:
+        self._client.delete(schedule_id=schedule_id)
+
+    def update_intervals(self, schedule_id: int, intervals) -> Schedule:
+        return self._client.update_intervals(
+            schedule_id=schedule_id,
+            entity=UpdateIntervalsCmd(intervals=intervals),
+        )
+
+    def create_holiday(self, schedule_id: int, **fields) -> Holiday:
+        return self._client.create_holiday(
+            schedule_id=schedule_id, entity=CreateHolidayCmd(**fields)
+        )
+
+    def update_holiday(
+        self, schedule_id: int, holiday_id: int, **fields
+    ) -> Holiday:
+        return self._client.update_holiday(
+            schedule_id=schedule_id,
+            holiday_id=holiday_id,
+            entity=UpdateHolidayCmd(**fields),
+        )
+
+    def delete_holiday(self, schedule_id: int, holiday_id: int) -> None:
+        self._client.delete_holiday(
+            schedule_id=schedule_id, holiday_id=holiday_id
+        )

--- a/libzapi/infrastructure/api_clients/ticketing/schedule_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/schedule_api_client.py
@@ -1,20 +1,34 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterator
 
-from libzapi.domain.models.ticketing.schedule import Schedule, Holiday
+from libzapi.application.commands.ticketing.schedule_cmds import (
+    CreateHolidayCmd,
+    CreateScheduleCmd,
+    UpdateHolidayCmd,
+    UpdateIntervalsCmd,
+    UpdateScheduleCmd,
+)
+from libzapi.domain.models.ticketing.schedule import Holiday, Schedule
 from libzapi.infrastructure.http.client import HttpClient
 from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.mappers.ticketing.schedule_mapper import (
+    to_payload_create_holiday,
+    to_payload_create_schedule,
+    to_payload_update_holiday,
+    to_payload_update_intervals,
+    to_payload_update_schedule,
+)
 from libzapi.infrastructure.serialization.parse import to_domain
 
 
 class ScheduleApiClient:
-    """HTTP adapter for Zendesk Schedule"""
+    """HTTP adapter for Zendesk Schedules with shared cursor pagination."""
 
     def __init__(self, http: HttpClient) -> None:
         self._http = http
 
-    def list(self) -> Iterable[Schedule]:
+    def list(self) -> Iterator[Schedule]:
         for obj in yield_items(
             get_json=self._http.get,
             first_path="/api/v2/business_hours/schedules",
@@ -23,19 +37,75 @@ class ScheduleApiClient:
         ):
             yield to_domain(data=obj, cls=Schedule)
 
-    def list_holidays(self, schedule_id) -> Iterable[Holiday]:
+    def list_holidays(self, schedule_id: int) -> Iterator[Holiday]:
         for obj in yield_items(
             get_json=self._http.get,
-            first_path=f"/api/v2/business_hours/schedules/{schedule_id}/holidays",
+            first_path=f"/api/v2/business_hours/schedules/{int(schedule_id)}/holidays",
             base_url=self._http.base_url,
             items_key="holidays",
         ):
             yield to_domain(data=obj, cls=Holiday)
 
     def get(self, schedule_id: int) -> Schedule:
-        data = self._http.get(f"/api/v2/business_hours/schedules/{schedule_id}")
+        data = self._http.get(
+            f"/api/v2/business_hours/schedules/{int(schedule_id)}"
+        )
         return to_domain(data=data["schedule"], cls=Schedule)
 
-    def get_holiday(self, schedule_id: int, holiday_id) -> Holiday:
-        data = self._http.get(f"/api/v2/business_hours/schedules/{schedule_id}/holidays/{holiday_id}")
+    def get_holiday(self, schedule_id: int, holiday_id: int) -> Holiday:
+        data = self._http.get(
+            f"/api/v2/business_hours/schedules/{int(schedule_id)}/holidays/{int(holiday_id)}"
+        )
         return to_domain(data=data["holiday"], cls=Holiday)
+
+    def create(self, entity: CreateScheduleCmd) -> Schedule:
+        payload = to_payload_create_schedule(entity)
+        data = self._http.post("/api/v2/business_hours/schedules", payload)
+        return to_domain(data=data["schedule"], cls=Schedule)
+
+    def update(self, schedule_id: int, entity: UpdateScheduleCmd) -> Schedule:
+        payload = to_payload_update_schedule(entity)
+        data = self._http.put(
+            f"/api/v2/business_hours/schedules/{int(schedule_id)}", payload
+        )
+        return to_domain(data=data["schedule"], cls=Schedule)
+
+    def delete(self, schedule_id: int) -> None:
+        self._http.delete(
+            f"/api/v2/business_hours/schedules/{int(schedule_id)}"
+        )
+
+    def update_intervals(
+        self, schedule_id: int, entity: UpdateIntervalsCmd
+    ) -> Schedule:
+        payload = to_payload_update_intervals(entity)
+        data = self._http.put(
+            f"/api/v2/business_hours/schedules/{int(schedule_id)}/workweek",
+            payload,
+        )
+        return to_domain(data=data["schedule"], cls=Schedule)
+
+    def create_holiday(
+        self, schedule_id: int, entity: CreateHolidayCmd
+    ) -> Holiday:
+        payload = to_payload_create_holiday(entity)
+        data = self._http.post(
+            f"/api/v2/business_hours/schedules/{int(schedule_id)}/holidays",
+            payload,
+        )
+        return to_domain(data=data["holiday"], cls=Holiday)
+
+    def update_holiday(
+        self, schedule_id: int, holiday_id: int, entity: UpdateHolidayCmd
+    ) -> Holiday:
+        payload = to_payload_update_holiday(entity)
+        data = self._http.put(
+            f"/api/v2/business_hours/schedules/{int(schedule_id)}/holidays/{int(holiday_id)}",
+            payload,
+        )
+        return to_domain(data=data["holiday"], cls=Holiday)
+
+    def delete_holiday(self, schedule_id: int, holiday_id: int) -> None:
+        self._http.delete(
+            f"/api/v2/business_hours/schedules/{int(schedule_id)}/holidays/{int(holiday_id)}"
+        )

--- a/libzapi/infrastructure/mappers/ticketing/schedule_mapper.py
+++ b/libzapi/infrastructure/mappers/ticketing/schedule_mapper.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from datetime import date
+
+from libzapi.application.commands.ticketing.schedule_cmds import (
+    CreateHolidayCmd,
+    CreateScheduleCmd,
+    UpdateHolidayCmd,
+    UpdateIntervalsCmd,
+    UpdateScheduleCmd,
+)
+
+
+def _format_date(value: date | str) -> str:
+    return value.isoformat() if isinstance(value, date) else value
+
+
+def to_payload_create_schedule(cmd: CreateScheduleCmd) -> dict:
+    body: dict = {"name": cmd.name, "time_zone": cmd.time_zone}
+    if cmd.intervals is not None:
+        body["intervals"] = list(cmd.intervals)
+    return {"schedule": body}
+
+
+def to_payload_update_schedule(cmd: UpdateScheduleCmd) -> dict:
+    body: dict = {}
+    if cmd.name is not None:
+        body["name"] = cmd.name
+    if cmd.time_zone is not None:
+        body["time_zone"] = cmd.time_zone
+    return {"schedule": body}
+
+
+def to_payload_update_intervals(cmd: UpdateIntervalsCmd) -> dict:
+    return {"workweek": {"intervals": list(cmd.intervals)}}
+
+
+def to_payload_create_holiday(cmd: CreateHolidayCmd) -> dict:
+    return {
+        "holiday": {
+            "name": cmd.name,
+            "start_date": _format_date(cmd.start_date),
+            "end_date": _format_date(cmd.end_date),
+        }
+    }
+
+
+def to_payload_update_holiday(cmd: UpdateHolidayCmd) -> dict:
+    body: dict = {}
+    if cmd.name is not None:
+        body["name"] = cmd.name
+    if cmd.start_date is not None:
+        body["start_date"] = _format_date(cmd.start_date)
+    if cmd.end_date is not None:
+        body["end_date"] = _format_date(cmd.end_date)
+    return {"holiday": body}

--- a/tests/integration/ticketing/test_schedule.py
+++ b/tests/integration/ticketing/test_schedule.py
@@ -1,0 +1,82 @@
+import uuid
+from datetime import date
+
+from libzapi import Ticketing
+
+
+def _unique() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+def _create_schedule(ticketing: Ticketing, **overrides):
+    suffix = _unique()
+    defaults = dict(
+        name=f"libzapi schedule {suffix}",
+        time_zone="Eastern Time (US & Canada)",
+    )
+    defaults.update(overrides)
+    return ticketing.schedules.create(**defaults)
+
+
+def test_list_and_get_schedule(ticketing: Ticketing):
+    schedules = list(ticketing.schedules.list_schedules())
+    assert isinstance(schedules, list)
+    if schedules:
+        schedule = ticketing.schedules.get_schedule(schedules[0].id)
+        assert schedule.id == schedules[0].id
+
+
+def test_create_update_delete_schedule(ticketing: Ticketing):
+    schedule = _create_schedule(ticketing)
+    try:
+        assert schedule.id > 0
+        updated = ticketing.schedules.update(
+            schedule.id, name=f"libzapi updated {_unique()}"
+        )
+        assert updated.name.startswith("libzapi updated")
+    finally:
+        ticketing.schedules.delete(schedule.id)
+
+
+def test_update_intervals(ticketing: Ticketing):
+    schedule = _create_schedule(ticketing)
+    try:
+        intervals = [
+            {"start_time": 1860, "end_time": 2280},
+            {"start_time": 3300, "end_time": 3720},
+        ]
+        result = ticketing.schedules.update_intervals(
+            schedule_id=schedule.id, intervals=intervals
+        )
+        assert result.id == schedule.id
+    finally:
+        ticketing.schedules.delete(schedule.id)
+
+
+def test_holiday_lifecycle(ticketing: Ticketing):
+    schedule = _create_schedule(ticketing)
+    try:
+        holiday = ticketing.schedules.create_holiday(
+            schedule_id=schedule.id,
+            name=f"libzapi holiday {_unique()}",
+            start_date=date(2030, 1, 1),
+            end_date=date(2030, 1, 2),
+        )
+        assert holiday.id > 0
+
+        fetched = ticketing.schedules.get_holiday(
+            schedule.id, holiday.id
+        )
+        assert fetched.id == holiday.id
+
+        listed = list(ticketing.schedules.list_holidays(schedule.id))
+        assert any(h.id == holiday.id for h in listed)
+
+        updated = ticketing.schedules.update_holiday(
+            schedule.id, holiday.id, name=f"libzapi updated {_unique()}"
+        )
+        assert updated.name.startswith("libzapi updated")
+
+        ticketing.schedules.delete_holiday(schedule.id, holiday.id)
+    finally:
+        ticketing.schedules.delete(schedule.id)

--- a/tests/unit/ticketing/test_schedule_client.py
+++ b/tests/unit/ticketing/test_schedule_client.py
@@ -1,0 +1,170 @@
+import pytest
+
+from libzapi.application.commands.ticketing.schedule_cmds import (
+    CreateHolidayCmd,
+    CreateScheduleCmd,
+    UpdateHolidayCmd,
+    UpdateIntervalsCmd,
+    UpdateScheduleCmd,
+)
+from libzapi.infrastructure.api_clients.ticketing import ScheduleApiClient
+
+
+_INTERVAL = [{"start_time": 1860, "end_time": 2280}]
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.schedule_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+@pytest.fixture
+def yield_items(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.schedule_api_client.yield_items"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schedule / Holiday reads
+# ---------------------------------------------------------------------------
+
+
+def test_list_schedules_yields_items(http, domain, yield_items):
+    yield_items.return_value = iter([{"id": 1}, {"id": 2}])
+    client = ScheduleApiClient(http)
+    result = list(client.list())
+    assert [r["id"] for r in result] == [1, 2]
+    assert all(r["_cls"] == "Schedule" for r in result)
+    kwargs = yield_items.call_args.kwargs
+    assert kwargs["first_path"] == "/api/v2/business_hours/schedules"
+    assert kwargs["items_key"] == "schedules"
+
+
+def test_list_holidays_yields_items(http, domain, yield_items):
+    yield_items.return_value = iter([{"id": 9}])
+    client = ScheduleApiClient(http)
+    result = list(client.list_holidays(schedule_id=5))
+    assert result[0]["_cls"] == "Holiday"
+    kwargs = yield_items.call_args.kwargs
+    assert kwargs["first_path"] == "/api/v2/business_hours/schedules/5/holidays"
+    assert kwargs["items_key"] == "holidays"
+
+
+def test_get_schedule_reads_schedule_key(http, domain):
+    http.get.return_value = {"schedule": {"id": 1, "name": "P"}}
+    client = ScheduleApiClient(http)
+    result = client.get(schedule_id=1)
+    http.get.assert_called_with("/api/v2/business_hours/schedules/1")
+    assert result["_cls"] == "Schedule"
+    assert result["name"] == "P"
+
+
+def test_get_holiday_reads_holiday_key(http, domain):
+    http.get.return_value = {"holiday": {"id": 9, "name": "H"}}
+    client = ScheduleApiClient(http)
+    result = client.get_holiday(schedule_id=5, holiday_id=9)
+    http.get.assert_called_with(
+        "/api/v2/business_hours/schedules/5/holidays/9"
+    )
+    assert result["_cls"] == "Holiday"
+    assert result["name"] == "H"
+
+
+# ---------------------------------------------------------------------------
+# Schedule CUD
+# ---------------------------------------------------------------------------
+
+
+def test_create_schedule_posts_payload(http, domain):
+    http.post.return_value = {"schedule": {"id": 1, "name": "P"}}
+    client = ScheduleApiClient(http)
+    result = client.create(CreateScheduleCmd(name="P", time_zone="UTC"))
+    http.post.assert_called_with(
+        "/api/v2/business_hours/schedules",
+        {"schedule": {"name": "P", "time_zone": "UTC"}},
+    )
+    assert result["name"] == "P"
+
+
+def test_update_schedule_puts_payload(http, domain):
+    http.put.return_value = {"schedule": {"id": 1, "name": "N"}}
+    client = ScheduleApiClient(http)
+    client.update(schedule_id=1, entity=UpdateScheduleCmd(name="N"))
+    http.put.assert_called_with(
+        "/api/v2/business_hours/schedules/1", {"schedule": {"name": "N"}}
+    )
+
+
+def test_delete_schedule_calls_delete(http):
+    client = ScheduleApiClient(http)
+    client.delete(schedule_id=7)
+    http.delete.assert_called_with("/api/v2/business_hours/schedules/7")
+
+
+def test_update_intervals_puts_payload(http, domain):
+    http.put.return_value = {"schedule": {"id": 1}}
+    client = ScheduleApiClient(http)
+    client.update_intervals(
+        schedule_id=1, entity=UpdateIntervalsCmd(intervals=_INTERVAL)
+    )
+    http.put.assert_called_with(
+        "/api/v2/business_hours/schedules/1/workweek",
+        {"workweek": {"intervals": _INTERVAL}},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Holiday CUD
+# ---------------------------------------------------------------------------
+
+
+def test_create_holiday_posts_payload(http, domain):
+    http.post.return_value = {"holiday": {"id": 9}}
+    client = ScheduleApiClient(http)
+    client.create_holiday(
+        schedule_id=5,
+        entity=CreateHolidayCmd(
+            name="H", start_date="2026-01-01", end_date="2026-01-02"
+        ),
+    )
+    http.post.assert_called_with(
+        "/api/v2/business_hours/schedules/5/holidays",
+        {
+            "holiday": {
+                "name": "H",
+                "start_date": "2026-01-01",
+                "end_date": "2026-01-02",
+            }
+        },
+    )
+
+
+def test_update_holiday_puts_payload(http, domain):
+    http.put.return_value = {"holiday": {"id": 9}}
+    client = ScheduleApiClient(http)
+    client.update_holiday(
+        schedule_id=5, holiday_id=9, entity=UpdateHolidayCmd(name="H2")
+    )
+    http.put.assert_called_with(
+        "/api/v2/business_hours/schedules/5/holidays/9",
+        {"holiday": {"name": "H2"}},
+    )
+
+
+def test_delete_holiday_calls_delete(http):
+    client = ScheduleApiClient(http)
+    client.delete_holiday(schedule_id=5, holiday_id=9)
+    http.delete.assert_called_with(
+        "/api/v2/business_hours/schedules/5/holidays/9"
+    )

--- a/tests/unit/ticketing/test_schedule_mapper.py
+++ b/tests/unit/ticketing/test_schedule_mapper.py
@@ -1,0 +1,132 @@
+from datetime import date
+
+from libzapi.application.commands.ticketing.schedule_cmds import (
+    CreateHolidayCmd,
+    CreateScheduleCmd,
+    UpdateHolidayCmd,
+    UpdateIntervalsCmd,
+    UpdateScheduleCmd,
+)
+from libzapi.infrastructure.mappers.ticketing.schedule_mapper import (
+    to_payload_create_holiday,
+    to_payload_create_schedule,
+    to_payload_update_holiday,
+    to_payload_update_intervals,
+    to_payload_update_schedule,
+)
+
+
+_INTERVAL = [{"start_time": 1860, "end_time": 2280}]
+
+
+# ---------------------------------------------------------------------------
+# Schedule create / update
+# ---------------------------------------------------------------------------
+
+
+def test_create_schedule_minimal_payload():
+    payload = to_payload_create_schedule(
+        CreateScheduleCmd(name="Primary", time_zone="UTC")
+    )
+    assert payload == {
+        "schedule": {"name": "Primary", "time_zone": "UTC"}
+    }
+
+
+def test_create_schedule_with_intervals():
+    body = to_payload_create_schedule(
+        CreateScheduleCmd(name="P", time_zone="UTC", intervals=_INTERVAL)
+    )["schedule"]
+    assert body["intervals"] == _INTERVAL
+
+
+def test_create_schedule_converts_intervals_iterable():
+    body = to_payload_create_schedule(
+        CreateScheduleCmd(name="P", time_zone="UTC", intervals=iter(_INTERVAL))
+    )["schedule"]
+    assert body["intervals"] == _INTERVAL
+
+
+def test_update_schedule_empty_patch():
+    assert to_payload_update_schedule(UpdateScheduleCmd()) == {"schedule": {}}
+
+
+def test_update_schedule_includes_fields():
+    body = to_payload_update_schedule(
+        UpdateScheduleCmd(name="N", time_zone="UTC")
+    )["schedule"]
+    assert body == {"name": "N", "time_zone": "UTC"}
+
+
+# ---------------------------------------------------------------------------
+# Intervals
+# ---------------------------------------------------------------------------
+
+
+def test_update_intervals_wraps_in_workweek():
+    payload = to_payload_update_intervals(
+        UpdateIntervalsCmd(intervals=_INTERVAL)
+    )
+    assert payload == {"workweek": {"intervals": _INTERVAL}}
+
+
+def test_update_intervals_converts_iterable():
+    payload = to_payload_update_intervals(
+        UpdateIntervalsCmd(intervals=iter(_INTERVAL))
+    )
+    assert payload == {"workweek": {"intervals": _INTERVAL}}
+
+
+# ---------------------------------------------------------------------------
+# Holiday create / update
+# ---------------------------------------------------------------------------
+
+
+def test_create_holiday_formats_dates():
+    payload = to_payload_create_holiday(
+        CreateHolidayCmd(
+            name="H",
+            start_date=date(2026, 1, 1),
+            end_date=date(2026, 1, 2),
+        )
+    )
+    assert payload == {
+        "holiday": {
+            "name": "H",
+            "start_date": "2026-01-01",
+            "end_date": "2026-01-02",
+        }
+    }
+
+
+def test_create_holiday_accepts_string_dates():
+    payload = to_payload_create_holiday(
+        CreateHolidayCmd(name="H", start_date="2026-01-01", end_date="2026-01-02")
+    )
+    assert payload["holiday"]["start_date"] == "2026-01-01"
+
+
+def test_update_holiday_empty_patch():
+    assert to_payload_update_holiday(UpdateHolidayCmd()) == {"holiday": {}}
+
+
+def test_update_holiday_includes_all_fields():
+    payload = to_payload_update_holiday(
+        UpdateHolidayCmd(
+            name="H2",
+            start_date=date(2026, 3, 1),
+            end_date=date(2026, 3, 2),
+        )
+    )
+    assert payload == {
+        "holiday": {
+            "name": "H2",
+            "start_date": "2026-03-01",
+            "end_date": "2026-03-02",
+        }
+    }
+
+
+def test_update_holiday_partial():
+    payload = to_payload_update_holiday(UpdateHolidayCmd(name="Only"))
+    assert payload == {"holiday": {"name": "Only"}}

--- a/tests/unit/ticketing/test_schedule_service.py
+++ b/tests/unit/ticketing/test_schedule_service.py
@@ -1,0 +1,161 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.commands.ticketing.schedule_cmds import (
+    CreateHolidayCmd,
+    CreateScheduleCmd,
+    UpdateHolidayCmd,
+    UpdateIntervalsCmd,
+    UpdateScheduleCmd,
+)
+from libzapi.application.services.ticketing.schedule_service import (
+    ScheduleService,
+)
+from libzapi.domain.errors import (
+    NotFound,
+    RateLimited,
+    Unauthorized,
+    UnprocessableEntity,
+)
+
+
+_INTERVAL = [{"start_time": 1860, "end_time": 2280}]
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return ScheduleService(client), client
+
+
+class TestDelegation:
+    def test_list_schedules_delegates(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.schedules
+        assert service.list_schedules() is sentinel.schedules
+
+    def test_get_schedule_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.schedule
+        assert service.get_schedule(5) is sentinel.schedule
+        client.get.assert_called_once_with(schedule_id=5)
+
+    def test_list_holidays_delegates(self):
+        service, client = _make_service()
+        client.list_holidays.return_value = sentinel.holidays
+        assert service.list_holidays(5) is sentinel.holidays
+        client.list_holidays.assert_called_once_with(schedule_id=5)
+
+    def test_get_holiday_delegates(self):
+        service, client = _make_service()
+        client.get_holiday.return_value = sentinel.holiday
+        assert service.get_holiday(5, 9) is sentinel.holiday
+        client.get_holiday.assert_called_once_with(schedule_id=5, holiday_id=9)
+
+    def test_delete_delegates(self):
+        service, client = _make_service()
+        service.delete(5)
+        client.delete.assert_called_once_with(schedule_id=5)
+
+    def test_delete_holiday_delegates(self):
+        service, client = _make_service()
+        service.delete_holiday(5, 9)
+        client.delete_holiday.assert_called_once_with(
+            schedule_id=5, holiday_id=9
+        )
+
+
+class TestCreate:
+    def test_builds_create_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.create.return_value = sentinel.schedule
+
+        result = service.create(name="P", time_zone="UTC")
+
+        cmd = client.create.call_args.kwargs["entity"]
+        assert isinstance(cmd, CreateScheduleCmd)
+        assert cmd.name == "P"
+        assert cmd.time_zone == "UTC"
+        assert result is sentinel.schedule
+
+
+class TestUpdate:
+    def test_builds_update_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.update.return_value = sentinel.schedule
+
+        result = service.update(7, name="N")
+
+        assert client.update.call_args.kwargs["schedule_id"] == 7
+        cmd = client.update.call_args.kwargs["entity"]
+        assert isinstance(cmd, UpdateScheduleCmd)
+        assert cmd.name == "N"
+        assert result is sentinel.schedule
+
+    def test_empty_fields_yields_blank_cmd(self):
+        service, client = _make_service()
+        service.update(1)
+        cmd = client.update.call_args.kwargs["entity"]
+        assert cmd.name is None
+
+
+class TestUpdateIntervals:
+    def test_builds_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.update_intervals.return_value = sentinel.schedule
+
+        result = service.update_intervals(schedule_id=5, intervals=_INTERVAL)
+
+        assert result is sentinel.schedule
+        assert client.update_intervals.call_args.kwargs["schedule_id"] == 5
+        cmd = client.update_intervals.call_args.kwargs["entity"]
+        assert isinstance(cmd, UpdateIntervalsCmd)
+        assert list(cmd.intervals) == _INTERVAL
+
+
+class TestHolidays:
+    def test_create_holiday_builds_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.create_holiday.return_value = sentinel.holiday
+
+        result = service.create_holiday(
+            schedule_id=5,
+            name="H",
+            start_date="2026-01-01",
+            end_date="2026-01-02",
+        )
+
+        cmd = client.create_holiday.call_args.kwargs["entity"]
+        assert isinstance(cmd, CreateHolidayCmd)
+        assert cmd.name == "H"
+        assert result is sentinel.holiday
+
+    def test_update_holiday_builds_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.update_holiday.return_value = sentinel.holiday
+
+        result = service.update_holiday(
+            schedule_id=5, holiday_id=9, name="H2"
+        )
+
+        cmd = client.update_holiday.call_args.kwargs["entity"]
+        assert isinstance(cmd, UpdateHolidayCmd)
+        assert cmd.name == "H2"
+        assert result is sentinel.holiday
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize(
+        "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+    )
+    def test_create_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.create.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.create(name="P", time_zone="UTC")
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_schedules_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.list.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list_schedules()


### PR DESCRIPTION
## Summary
- Adds full CUD on schedules plus workweek intervals update and holiday CUD.
- New `Create/Update/UpdateIntervals/CreateHoliday/UpdateHoliday` command dataclasses and matching payload mappers (date objects serialised to ISO strings).
- Extends `ScheduleApiClient` and `ScheduleService` with create/update/delete/update_intervals/create_holiday/update_holiday/delete_holiday.

Refs #79.

## Test plan
- [x] `uv run --python 3.12 pytest tests/unit/ticketing/` — 618 passed
- [x] 100% coverage across schedule_cmds / schedule_mapper / schedule_api_client / schedule_service / schedule domain model
- [ ] Live integration tests in `tests/integration/ticketing/test_schedule.py` on a real tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)