### PR TITLE
feat(ticketing): support addresses CUD + verify

### DIFF
--- a/libzapi/application/commands/ticketing/support_address_cmds.py
+++ b/libzapi/application/commands/ticketing/support_address_cmds.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TypeAlias
+
+
+@dataclass(frozen=True, slots=True)
+class CreateSupportAddressCmd:
+    email: str
+    name: str | None = None
+    brand_id: int | None = None
+    default: bool | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateSupportAddressCmd:
+    name: str | None = None
+    brand_id: int | None = None
+    default: bool | None = None
+
+
+SupportAddressCmd: TypeAlias = CreateSupportAddressCmd | UpdateSupportAddressCmd

--- a/libzapi/application/services/ticketing/support_addresses_service.py
+++ b/libzapi/application/services/ticketing/support_addresses_service.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
 from typing import Iterable
 
+from libzapi.application.commands.ticketing.support_address_cmds import (
+    CreateSupportAddressCmd,
+    UpdateSupportAddressCmd,
+)
 from libzapi.domain.models.ticketing.support_address import RecipientAddress
-from libzapi.infrastructure.api_clients.ticketing.support_address_api_client import SupportAddressApiClient
+from libzapi.infrastructure.api_clients.ticketing.support_address_api_client import (
+    SupportAddressApiClient,
+)
 
 
 class SupportAddressesService:
@@ -15,3 +23,18 @@ class SupportAddressesService:
 
     def get(self, support_address_id: int) -> RecipientAddress:
         return self._client.get(support_address_id)
+
+    def create(self, **fields) -> RecipientAddress:
+        return self._client.create(entity=CreateSupportAddressCmd(**fields))
+
+    def update(self, support_address_id: int, **fields) -> RecipientAddress:
+        return self._client.update(
+            support_address_id=support_address_id,
+            entity=UpdateSupportAddressCmd(**fields),
+        )
+
+    def delete(self, support_address_id: int) -> None:
+        self._client.delete(support_address_id=support_address_id)
+
+    def verify(self, support_address_id: int) -> dict:
+        return self._client.verify(support_address_id=support_address_id)

--- a/libzapi/infrastructure/api_clients/ticketing/support_address_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/support_address_api_client.py
@@ -2,14 +2,22 @@ from __future__ import annotations
 
 from typing import Iterator
 
+from libzapi.application.commands.ticketing.support_address_cmds import (
+    CreateSupportAddressCmd,
+    UpdateSupportAddressCmd,
+)
 from libzapi.domain.models.ticketing.support_address import RecipientAddress
 from libzapi.infrastructure.http.client import HttpClient
 from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.mappers.ticketing.support_address_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
 from libzapi.infrastructure.serialization.parse import to_domain
 
 
 class SupportAddressApiClient:
-    """HTTP adapter for Zendesk Account Settings"""
+    """HTTP adapter for Zendesk Recipient Addresses."""
 
     def __init__(self, http: HttpClient) -> None:
         self._http = http
@@ -23,6 +31,33 @@ class SupportAddressApiClient:
         ):
             yield to_domain(data=obj, cls=RecipientAddress)
 
-    def get(self, support_address_id) -> RecipientAddress:
-        data = self._http.get(f"/api/v2/recipient_addresses/{support_address_id}")
+    def get(self, support_address_id: int) -> RecipientAddress:
+        data = self._http.get(
+            f"/api/v2/recipient_addresses/{int(support_address_id)}"
+        )
         return to_domain(data=data["recipient_address"], cls=RecipientAddress)
+
+    def create(self, entity: CreateSupportAddressCmd) -> RecipientAddress:
+        payload = to_payload_create(entity)
+        data = self._http.post("/api/v2/recipient_addresses", payload)
+        return to_domain(data=data["recipient_address"], cls=RecipientAddress)
+
+    def update(
+        self, support_address_id: int, entity: UpdateSupportAddressCmd
+    ) -> RecipientAddress:
+        payload = to_payload_update(entity)
+        data = self._http.put(
+            f"/api/v2/recipient_addresses/{int(support_address_id)}", payload
+        )
+        return to_domain(data=data["recipient_address"], cls=RecipientAddress)
+
+    def delete(self, support_address_id: int) -> None:
+        self._http.delete(
+            f"/api/v2/recipient_addresses/{int(support_address_id)}"
+        )
+
+    def verify(self, support_address_id: int) -> dict:
+        return self._http.put(
+            f"/api/v2/recipient_addresses/{int(support_address_id)}/verify",
+            {},
+        )

--- a/libzapi/infrastructure/mappers/ticketing/support_address_mapper.py
+++ b/libzapi/infrastructure/mappers/ticketing/support_address_mapper.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from libzapi.application.commands.ticketing.support_address_cmds import (
+    CreateSupportAddressCmd,
+    UpdateSupportAddressCmd,
+)
+
+
+_OPTIONAL_FIELDS = ("name", "brand_id", "default")
+
+
+def _add_optionals(body: dict, cmd) -> None:
+    for field in _OPTIONAL_FIELDS:
+        value = getattr(cmd, field)
+        if value is not None:
+            body[field] = value
+
+
+def to_payload_create(cmd: CreateSupportAddressCmd) -> dict:
+    body: dict = {"email": cmd.email}
+    _add_optionals(body, cmd)
+    return {"recipient_address": body}
+
+
+def to_payload_update(cmd: UpdateSupportAddressCmd) -> dict:
+    body: dict = {}
+    _add_optionals(body, cmd)
+    return {"recipient_address": body}

--- a/tests/integration/ticketing/test_support_address.py
+++ b/tests/integration/ticketing/test_support_address.py
@@ -1,8 +1,30 @@
+import uuid
+
 from libzapi import Ticketing
 
 
-def test_list_and_get_support_settings(ticketing: Ticketing):
+def _unique() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+def test_list_and_get_support_addresses(ticketing: Ticketing):
     addresses = list(ticketing.support_addresses.list())
     assert len(addresses) > 0
     address = ticketing.support_addresses.get(addresses[0].id)
     assert address.name == addresses[0].name
+
+
+def test_create_update_delete_support_address(ticketing: Ticketing):
+    suffix = _unique()
+    address = ticketing.support_addresses.create(
+        email=f"libzapi+{suffix}@libzapi.test",
+        name=f"libzapi {suffix}",
+    )
+    try:
+        assert address.id > 0
+        updated = ticketing.support_addresses.update(
+            address.id, name=f"libzapi updated {suffix}"
+        )
+        assert updated.name.startswith("libzapi updated")
+    finally:
+        ticketing.support_addresses.delete(address.id)

--- a/tests/unit/ticketing/test_support_address_client.py
+++ b/tests/unit/ticketing/test_support_address_client.py
@@ -1,0 +1,87 @@
+import pytest
+
+from libzapi.application.commands.ticketing.support_address_cmds import (
+    CreateSupportAddressCmd,
+    UpdateSupportAddressCmd,
+)
+from libzapi.infrastructure.api_clients.ticketing.support_address_api_client import (
+    SupportAddressApiClient,
+)
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.support_address_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+@pytest.fixture
+def yield_items(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.support_address_api_client.yield_items"
+    )
+
+
+def test_list_yields_items(http, domain, yield_items):
+    yield_items.return_value = iter([{"id": 1}, {"id": 2}])
+    client = SupportAddressApiClient(http)
+    result = list(client.list())
+    assert [r["id"] for r in result] == [1, 2]
+    assert all(r["_cls"] == "RecipientAddress" for r in result)
+    kwargs = yield_items.call_args.kwargs
+    assert kwargs["first_path"] == "/api/v2/recipient_addresses"
+    assert kwargs["items_key"] == "recipient_addresses"
+
+
+def test_get_reads_recipient_address_key(http, domain):
+    http.get.return_value = {"recipient_address": {"id": 7, "name": "N"}}
+    client = SupportAddressApiClient(http)
+    result = client.get(support_address_id=7)
+    http.get.assert_called_with("/api/v2/recipient_addresses/7")
+    assert result["_cls"] == "RecipientAddress"
+    assert result["name"] == "N"
+
+
+def test_create_posts_payload(http, domain):
+    http.post.return_value = {"recipient_address": {"id": 1, "email": "x@x"}}
+    client = SupportAddressApiClient(http)
+    result = client.create(CreateSupportAddressCmd(email="x@x"))
+    http.post.assert_called_with(
+        "/api/v2/recipient_addresses",
+        {"recipient_address": {"email": "x@x"}},
+    )
+    assert result["_cls"] == "RecipientAddress"
+
+
+def test_update_puts_payload(http, domain):
+    http.put.return_value = {"recipient_address": {"id": 1, "name": "N"}}
+    client = SupportAddressApiClient(http)
+    client.update(
+        support_address_id=1, entity=UpdateSupportAddressCmd(name="N")
+    )
+    http.put.assert_called_with(
+        "/api/v2/recipient_addresses/1", {"recipient_address": {"name": "N"}}
+    )
+
+
+def test_delete_calls_delete(http):
+    client = SupportAddressApiClient(http)
+    client.delete(support_address_id=9)
+    http.delete.assert_called_with("/api/v2/recipient_addresses/9")
+
+
+def test_verify_puts_empty_body(http):
+    http.put.return_value = {"status": "ok"}
+    client = SupportAddressApiClient(http)
+    result = client.verify(support_address_id=3)
+    http.put.assert_called_with("/api/v2/recipient_addresses/3/verify", {})
+    assert result == {"status": "ok"}

--- a/tests/unit/ticketing/test_support_address_mapper.py
+++ b/tests/unit/ticketing/test_support_address_mapper.py
@@ -1,0 +1,56 @@
+from libzapi.application.commands.ticketing.support_address_cmds import (
+    CreateSupportAddressCmd,
+    UpdateSupportAddressCmd,
+)
+from libzapi.infrastructure.mappers.ticketing.support_address_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
+
+
+def test_create_minimal_payload():
+    payload = to_payload_create(CreateSupportAddressCmd(email="hi@x.com"))
+    assert payload == {"recipient_address": {"email": "hi@x.com"}}
+
+
+def test_create_includes_all_optionals():
+    payload = to_payload_create(
+        CreateSupportAddressCmd(
+            email="hi@x.com", name="Support", brand_id=3, default=False
+        )
+    )
+    assert payload == {
+        "recipient_address": {
+            "email": "hi@x.com",
+            "name": "Support",
+            "brand_id": 3,
+            "default": False,
+        }
+    }
+
+
+def test_create_preserves_false_default():
+    payload = to_payload_create(
+        CreateSupportAddressCmd(email="hi@x.com", default=False)
+    )
+    assert payload["recipient_address"]["default"] is False
+
+
+def test_update_empty_patch():
+    assert to_payload_update(UpdateSupportAddressCmd()) == {
+        "recipient_address": {}
+    }
+
+
+def test_update_includes_fields():
+    payload = to_payload_update(
+        UpdateSupportAddressCmd(name="N", brand_id=1, default=True)
+    )
+    assert payload == {
+        "recipient_address": {"name": "N", "brand_id": 1, "default": True}
+    }
+
+
+def test_update_preserves_false_default():
+    payload = to_payload_update(UpdateSupportAddressCmd(default=False))
+    assert payload["recipient_address"]["default"] is False

--- a/tests/unit/ticketing/test_support_addresses_service.py
+++ b/tests/unit/ticketing/test_support_addresses_service.py
@@ -1,0 +1,100 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.commands.ticketing.support_address_cmds import (
+    CreateSupportAddressCmd,
+    UpdateSupportAddressCmd,
+)
+from libzapi.application.services.ticketing.support_addresses_service import (
+    SupportAddressesService,
+)
+from libzapi.domain.errors import (
+    NotFound,
+    RateLimited,
+    Unauthorized,
+    UnprocessableEntity,
+)
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return SupportAddressesService(client), client
+
+
+class TestDelegation:
+    def test_list_delegates(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.addresses
+        assert service.list() is sentinel.addresses
+
+    def test_get_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.address
+        assert service.get(7) is sentinel.address
+        client.get.assert_called_once_with(7)
+
+    def test_delete_delegates(self):
+        service, client = _make_service()
+        service.delete(5)
+        client.delete.assert_called_once_with(support_address_id=5)
+
+    def test_verify_delegates(self):
+        service, client = _make_service()
+        client.verify.return_value = {"status": "ok"}
+        assert service.verify(5) == {"status": "ok"}
+        client.verify.assert_called_once_with(support_address_id=5)
+
+
+class TestCreate:
+    def test_builds_create_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.create.return_value = sentinel.address
+
+        result = service.create(email="x@x", name="N", brand_id=1)
+
+        cmd = client.create.call_args.kwargs["entity"]
+        assert isinstance(cmd, CreateSupportAddressCmd)
+        assert cmd.email == "x@x"
+        assert cmd.name == "N"
+        assert cmd.brand_id == 1
+        assert result is sentinel.address
+
+
+class TestUpdate:
+    def test_builds_update_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.update.return_value = sentinel.address
+
+        result = service.update(7, name="N")
+
+        assert client.update.call_args.kwargs["support_address_id"] == 7
+        cmd = client.update.call_args.kwargs["entity"]
+        assert isinstance(cmd, UpdateSupportAddressCmd)
+        assert cmd.name == "N"
+        assert result is sentinel.address
+
+    def test_empty_fields_yields_blank_cmd(self):
+        service, client = _make_service()
+        service.update(1)
+        cmd = client.update.call_args.kwargs["entity"]
+        assert cmd.name is None
+        assert cmd.brand_id is None
+        assert cmd.default is None
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize(
+        "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+    )
+    def test_create_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.create.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.create(email="x@x")
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.list.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list()


### PR DESCRIPTION
## Summary
- Adds full CUD on Zendesk recipient (support) addresses plus a `verify` action.
- New `Create/Update` command dataclasses and payload mappers (preserves `false` booleans, skips `None`).
- Extends `SupportAddressApiClient` and `SupportAddressesService` with create/update/delete/verify.

Refs #79.

## Test plan
- [x] `uv run --python 3.12 pytest tests/unit/` — 1879 passed
- [x] 100% coverage across support_address_cmds / support_address_mapper / support_address_api_client / support_addresses_service / support_address domain model
- [ ] Live integration tests on a real tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)