### PR TITLE
feat(ticketing): suspended ticket actions (recover, delete, attachments)

### DIFF
--- a/libzapi/application/services/ticketing/suspended_tickets_service.py
+++ b/libzapi/application/services/ticketing/suspended_tickets_service.py
@@ -1,7 +1,12 @@
+from __future__ import annotations
+
 from typing import Iterable
 
+from libzapi.domain.models.ticketing.attachment import Attachment
 from libzapi.domain.models.ticketing.suspended_ticket import SuspendedTicket
-from libzapi.infrastructure.api_clients.ticketing import SuspendedTicketApiClient
+from libzapi.infrastructure.api_clients.ticketing import (
+    SuspendedTicketApiClient,
+)
 
 
 class SuspendedTicketsService:
@@ -15,3 +20,18 @@ class SuspendedTicketsService:
 
     def get_by_id(self, id_: int) -> SuspendedTicket:
         return self._client.get(id_)
+
+    def recover(self, id_: int) -> SuspendedTicket:
+        return self._client.recover(id_)
+
+    def recover_many(self, ids: Iterable[int]) -> dict:
+        return self._client.recover_many(ids)
+
+    def delete(self, id_: int) -> None:
+        self._client.delete(id_)
+
+    def destroy_many(self, ids: Iterable[int]) -> dict:
+        return self._client.destroy_many(ids)
+
+    def list_attachments(self, id_: int) -> list[Attachment]:
+        return self._client.list_attachments(id_)

--- a/libzapi/infrastructure/api_clients/ticketing/suspended_ticket_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/suspended_ticket_api_client.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Iterator
 
+from libzapi.domain.models.ticketing.attachment import Attachment
 from libzapi.domain.models.ticketing.suspended_ticket import SuspendedTicket
 from libzapi.infrastructure.http.client import HttpClient
 from libzapi.infrastructure.http.pagination import yield_items
@@ -9,12 +10,12 @@ from libzapi.infrastructure.serialization.parse import to_domain
 
 
 class SuspendedTicketApiClient:
-    """HTTP adapter for Zendesk Suspended Tickets with shared cursor pagination."""
+    """HTTP adapter for Zendesk Suspended Tickets."""
 
     def __init__(self, http: HttpClient) -> None:
         self._http = http
 
-    def list(self) -> Iterable[SuspendedTicket]:
+    def list(self) -> Iterator[SuspendedTicket]:
         for obj in yield_items(
             get_json=self._http.get,
             first_path="/api/v2/suspended_tickets",
@@ -26,3 +27,39 @@ class SuspendedTicketApiClient:
     def get(self, id_: int) -> SuspendedTicket:
         data = self._http.get(f"/api/v2/suspended_tickets/{int(id_)}")
         return to_domain(data=data["suspended_ticket"], cls=SuspendedTicket)
+
+    def recover(self, id_: int) -> SuspendedTicket:
+        data = self._http.put(
+            f"/api/v2/suspended_tickets/{int(id_)}/recover", {}
+        )
+        return to_domain(data=data["suspended_ticket"], cls=SuspendedTicket)
+
+    def recover_many(self, ids: Iterable[int]) -> dict:
+        ids_str = ",".join(str(int(i)) for i in ids)
+        return (
+            self._http.put(
+                f"/api/v2/suspended_tickets/recover_many?ids={ids_str}", {}
+            )
+            or {}
+        )
+
+    def delete(self, id_: int) -> None:
+        self._http.delete(f"/api/v2/suspended_tickets/{int(id_)}")
+
+    def destroy_many(self, ids: Iterable[int]) -> dict:
+        ids_str = ",".join(str(int(i)) for i in ids)
+        return (
+            self._http.delete(
+                f"/api/v2/suspended_tickets/destroy_many?ids={ids_str}"
+            )
+            or {}
+        )
+
+    def list_attachments(self, id_: int) -> list[Attachment]:
+        data = self._http.get(
+            f"/api/v2/suspended_tickets/{int(id_)}/attachments"
+        )
+        return [
+            to_domain(data=item, cls=Attachment)
+            for item in (data.get("attachments") or [])
+        ]

--- a/tests/integration/ticketing/test_suspended_ticket.py
+++ b/tests/integration/ticketing/test_suspended_ticket.py
@@ -3,7 +3,17 @@ from libzapi import Ticketing
 
 def test_list_and_get(ticketing: Ticketing):
     collection = list(ticketing.suspended_tickets.list_all())
-    if len(collection) > 0:
-        item = ticketing.suspended_tickets.get(collection[0].id)
-        assert item.name == collection[0].name
     assert isinstance(collection, list)
+    if collection:
+        item = ticketing.suspended_tickets.get_by_id(collection[0].id)
+        assert item.id == collection[0].id
+
+
+def test_list_attachments(ticketing: Ticketing):
+    collection = list(ticketing.suspended_tickets.list_all())
+    if not collection:
+        return
+    attachments = ticketing.suspended_tickets.list_attachments(
+        collection[0].id
+    )
+    assert isinstance(attachments, list)

--- a/tests/unit/ticketing/test_suspended_ticket_client.py
+++ b/tests/unit/ticketing/test_suspended_ticket_client.py
@@ -1,0 +1,109 @@
+import pytest
+
+from libzapi.infrastructure.api_clients.ticketing.suspended_ticket_api_client import (
+    SuspendedTicketApiClient,
+)
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.suspended_ticket_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+@pytest.fixture
+def yield_items(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.suspended_ticket_api_client.yield_items"
+    )
+
+
+def test_list_yields_items(http, domain, yield_items):
+    yield_items.return_value = iter([{"id": 1}, {"id": 2}])
+    client = SuspendedTicketApiClient(http)
+    result = list(client.list())
+    assert [r["id"] for r in result] == [1, 2]
+    assert all(r["_cls"] == "SuspendedTicket" for r in result)
+    kwargs = yield_items.call_args.kwargs
+    assert kwargs["first_path"] == "/api/v2/suspended_tickets"
+    assert kwargs["items_key"] == "suspended_tickets"
+
+
+def test_get_reads_suspended_ticket_key(http, domain):
+    http.get.return_value = {"suspended_ticket": {"id": 7}}
+    client = SuspendedTicketApiClient(http)
+    result = client.get(id_=7)
+    http.get.assert_called_with("/api/v2/suspended_tickets/7")
+    assert result["_cls"] == "SuspendedTicket"
+
+
+def test_recover_puts_empty_body(http, domain):
+    http.put.return_value = {"suspended_ticket": {"id": 7}}
+    client = SuspendedTicketApiClient(http)
+    result = client.recover(id_=7)
+    http.put.assert_called_with("/api/v2/suspended_tickets/7/recover", {})
+    assert result["_cls"] == "SuspendedTicket"
+
+
+def test_recover_many_puts_ids_query(http):
+    http.put.return_value = {"status": "ok"}
+    client = SuspendedTicketApiClient(http)
+    result = client.recover_many(ids=[1, 2, 3])
+    http.put.assert_called_with(
+        "/api/v2/suspended_tickets/recover_many?ids=1,2,3", {}
+    )
+    assert result == {"status": "ok"}
+
+
+def test_recover_many_handles_none_response(http):
+    http.put.return_value = None
+    client = SuspendedTicketApiClient(http)
+    assert client.recover_many(ids=[1]) == {}
+
+
+def test_delete_calls_delete(http):
+    client = SuspendedTicketApiClient(http)
+    client.delete(id_=9)
+    http.delete.assert_called_with("/api/v2/suspended_tickets/9")
+
+
+def test_destroy_many_deletes_with_ids_query(http):
+    http.delete.return_value = {"status": "ok"}
+    client = SuspendedTicketApiClient(http)
+    result = client.destroy_many(ids=[4, 5])
+    http.delete.assert_called_with(
+        "/api/v2/suspended_tickets/destroy_many?ids=4,5"
+    )
+    assert result == {"status": "ok"}
+
+
+def test_destroy_many_handles_none_response(http):
+    http.delete.return_value = None
+    client = SuspendedTicketApiClient(http)
+    assert client.destroy_many(ids=[1]) == {}
+
+
+def test_list_attachments_returns_attachment_list(http, domain):
+    http.get.return_value = {
+        "attachments": [{"id": 1}, {"id": 2}]
+    }
+    client = SuspendedTicketApiClient(http)
+    result = client.list_attachments(id_=7)
+    http.get.assert_called_with("/api/v2/suspended_tickets/7/attachments")
+    assert [r["id"] for r in result] == [1, 2]
+    assert all(r["_cls"] == "Attachment" for r in result)
+
+
+def test_list_attachments_handles_missing_key(http, domain):
+    http.get.return_value = {}
+    client = SuspendedTicketApiClient(http)
+    assert client.list_attachments(id_=7) == []

--- a/tests/unit/ticketing/test_suspended_tickets_service.py
+++ b/tests/unit/ticketing/test_suspended_tickets_service.py
@@ -1,0 +1,70 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.services.ticketing.suspended_tickets_service import (
+    SuspendedTicketsService,
+)
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return SuspendedTicketsService(client), client
+
+
+class TestDelegation:
+    def test_list_all_delegates(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.items
+        assert service.list_all() is sentinel.items
+
+    def test_get_by_id_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.item
+        assert service.get_by_id(7) is sentinel.item
+        client.get.assert_called_once_with(7)
+
+    def test_recover_delegates(self):
+        service, client = _make_service()
+        client.recover.return_value = sentinel.item
+        assert service.recover(7) is sentinel.item
+        client.recover.assert_called_once_with(7)
+
+    def test_recover_many_delegates(self):
+        service, client = _make_service()
+        client.recover_many.return_value = {"status": "ok"}
+        assert service.recover_many([1, 2]) == {"status": "ok"}
+        client.recover_many.assert_called_once_with([1, 2])
+
+    def test_delete_delegates(self):
+        service, client = _make_service()
+        service.delete(5)
+        client.delete.assert_called_once_with(5)
+
+    def test_destroy_many_delegates(self):
+        service, client = _make_service()
+        client.destroy_many.return_value = {"status": "ok"}
+        assert service.destroy_many([1, 2]) == {"status": "ok"}
+        client.destroy_many.assert_called_once_with([1, 2])
+
+    def test_list_attachments_delegates(self):
+        service, client = _make_service()
+        client.list_attachments.return_value = sentinel.atts
+        assert service.list_attachments(7) is sentinel.atts
+        client.list_attachments.assert_called_once_with(7)
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_recover_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.recover.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.recover(1)
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.list.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list_all()


### PR DESCRIPTION
## Summary
- Adds `recover`/`recover_many`, `delete`/`destroy_many` and `list_attachments` to the suspended-tickets API client and service.
- Integration test extended to exercise `list_attachments` when any suspended ticket is available.

Refs #79.

## Test plan
- [x] `uv run --python 3.12 pytest tests/unit/` — 1875 passed
- [x] 100% coverage across suspended_ticket_api_client / suspended_tickets_service / suspended_ticket domain model
- [ ] Live integration tests on a real tenant (skips gracefully when no suspended tickets exist)

🤖 Generated with [Claude Code](https://claude.com/claude-code)