### PR TITLE
feat(ticketing): requests CUD + search + comments

### DIFF
--- a/libzapi/application/commands/ticketing/request_cmds.py
+++ b/libzapi/application/commands/ticketing/request_cmds.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, TypeAlias
+
+
+@dataclass(frozen=True, slots=True)
+class CreateRequestCmd:
+    subject: str
+    comment: dict[str, Any]
+    requester: dict[str, Any] | None = None
+    priority: str | None = None
+    type: str | None = None
+    custom_fields: Iterable[dict[str, Any]] | None = None
+    ticket_form_id: int | None = None
+    recipient: str | None = None
+    collaborators: Iterable[Any] | None = None
+    email_ccs: Iterable[Any] | None = None
+    due_at: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateRequestCmd:
+    comment: dict[str, Any] | None = None
+    solved: bool | None = None
+    additional_collaborators: Iterable[Any] | None = None
+    email_ccs: Iterable[Any] | None = None
+
+
+RequestCmd: TypeAlias = CreateRequestCmd | UpdateRequestCmd

--- a/libzapi/application/services/ticketing/requests_service.py
+++ b/libzapi/application/services/ticketing/requests_service.py
@@ -1,7 +1,15 @@
-from typing import Iterable
+from __future__ import annotations
 
-from libzapi.infrastructure.api_clients.ticketing.request_api_client import RequestApiClient
+from typing import Iterable, Iterator
+
+from libzapi.application.commands.ticketing.request_cmds import (
+    CreateRequestCmd,
+    UpdateRequestCmd,
+)
 from libzapi.domain.models.ticketing.request import Request
+from libzapi.infrastructure.api_clients.ticketing.request_api_client import (
+    RequestApiClient,
+)
 
 
 class RequestsService:
@@ -10,8 +18,30 @@ class RequestsService:
     def __init__(self, client: RequestApiClient) -> None:
         self._client = client
 
-    def list_by_user(self, user_id) -> Iterable[Request]:
+    def list_all(self) -> Iterable[Request]:
+        return self._client.list()
+
+    def list_by_user(self, user_id: int) -> Iterable[Request]:
         return self._client.list_user(user_id)
+
+    def search(self, query: str) -> Iterable[Request]:
+        return self._client.search(query)
 
     def get_by_id(self, request_id: int) -> Request:
         return self._client.get(request_id)
+
+    def create(self, **fields) -> Request:
+        return self._client.create(entity=CreateRequestCmd(**fields))
+
+    def update(self, request_id: int, **fields) -> Request:
+        return self._client.update(
+            request_id=request_id, entity=UpdateRequestCmd(**fields)
+        )
+
+    def list_comments(self, request_id: int) -> Iterator[dict]:
+        return self._client.list_comments(request_id)
+
+    def get_comment(self, request_id: int, comment_id: int) -> dict:
+        return self._client.get_comment(
+            request_id=request_id, comment_id=comment_id
+        )

--- a/libzapi/infrastructure/api_clients/ticketing/request_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/request_api_client.py
@@ -1,20 +1,38 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterator
+from urllib.parse import quote
 
+from libzapi.application.commands.ticketing.request_cmds import (
+    CreateRequestCmd,
+    UpdateRequestCmd,
+)
 from libzapi.domain.models.ticketing.request import Request
 from libzapi.infrastructure.http.client import HttpClient
 from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.mappers.ticketing.request_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
 from libzapi.infrastructure.serialization.parse import to_domain
 
 
 class RequestApiClient:
-    """HTTP adapter for Zendesk Groups with shared cursor pagination."""
+    """HTTP adapter for Zendesk Requests."""
 
     def __init__(self, http: HttpClient) -> None:
         self._http = http
 
-    def list_user(self, user_id: int) -> Iterable[Request]:
+    def list(self) -> Iterator[Request]:
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path="/api/v2/requests",
+            base_url=self._http.base_url,
+            items_key="requests",
+        ):
+            yield to_domain(data=obj, cls=Request)
+
+    def list_user(self, user_id: int) -> Iterator[Request]:
         for obj in yield_items(
             get_json=self._http.get,
             first_path=f"/api/v2/users/{int(user_id)}/requests",
@@ -23,6 +41,41 @@ class RequestApiClient:
         ):
             yield to_domain(data=obj, cls=Request)
 
+    def search(self, query: str) -> Iterator[Request]:
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path=f"/api/v2/requests/search?query={quote(query)}",
+            base_url=self._http.base_url,
+            items_key="requests",
+        ):
+            yield to_domain(data=obj, cls=Request)
+
     def get(self, request_id: int) -> Request:
         data = self._http.get(f"/api/v2/requests/{int(request_id)}")
         return to_domain(data=data["request"], cls=Request)
+
+    def create(self, entity: CreateRequestCmd) -> Request:
+        payload = to_payload_create(entity)
+        data = self._http.post("/api/v2/requests", payload)
+        return to_domain(data=data["request"], cls=Request)
+
+    def update(self, request_id: int, entity: UpdateRequestCmd) -> Request:
+        payload = to_payload_update(entity)
+        data = self._http.put(
+            f"/api/v2/requests/{int(request_id)}", payload
+        )
+        return to_domain(data=data["request"], cls=Request)
+
+    def list_comments(self, request_id: int) -> Iterator[dict]:
+        yield from yield_items(
+            get_json=self._http.get,
+            first_path=f"/api/v2/requests/{int(request_id)}/comments",
+            base_url=self._http.base_url,
+            items_key="comments",
+        )
+
+    def get_comment(self, request_id: int, comment_id: int) -> dict:
+        data = self._http.get(
+            f"/api/v2/requests/{int(request_id)}/comments/{int(comment_id)}"
+        )
+        return data["comment"]

--- a/libzapi/infrastructure/mappers/ticketing/request_mapper.py
+++ b/libzapi/infrastructure/mappers/ticketing/request_mapper.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from libzapi.application.commands.ticketing.request_cmds import (
+    CreateRequestCmd,
+    UpdateRequestCmd,
+)
+
+
+def to_payload_create(cmd: CreateRequestCmd) -> dict:
+    body: dict = {"subject": cmd.subject, "comment": dict(cmd.comment)}
+    if cmd.requester is not None:
+        body["requester"] = dict(cmd.requester)
+    if cmd.priority is not None:
+        body["priority"] = cmd.priority
+    if cmd.type is not None:
+        body["type"] = cmd.type
+    if cmd.custom_fields is not None:
+        body["custom_fields"] = [dict(f) for f in cmd.custom_fields]
+    if cmd.ticket_form_id is not None:
+        body["ticket_form_id"] = cmd.ticket_form_id
+    if cmd.recipient is not None:
+        body["recipient"] = cmd.recipient
+    if cmd.collaborators is not None:
+        body["collaborators"] = list(cmd.collaborators)
+    if cmd.email_ccs is not None:
+        body["email_ccs"] = list(cmd.email_ccs)
+    if cmd.due_at is not None:
+        body["due_at"] = cmd.due_at
+    return {"request": body}
+
+
+def to_payload_update(cmd: UpdateRequestCmd) -> dict:
+    body: dict = {}
+    if cmd.comment is not None:
+        body["comment"] = dict(cmd.comment)
+    if cmd.solved is not None:
+        body["solved"] = cmd.solved
+    if cmd.additional_collaborators is not None:
+        body["additional_collaborators"] = list(cmd.additional_collaborators)
+    if cmd.email_ccs is not None:
+        body["email_ccs"] = list(cmd.email_ccs)
+    return {"request": body}

--- a/tests/integration/ticketing/test_request.py
+++ b/tests/integration/ticketing/test_request.py
@@ -1,0 +1,41 @@
+import itertools
+import uuid
+
+from libzapi import Ticketing
+
+
+def _unique() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+def test_list_requests(ticketing: Ticketing):
+    requests = list(itertools.islice(ticketing.requests.list_all(), 5))
+    assert isinstance(requests, list)
+
+
+def test_create_update_and_solve(ticketing: Ticketing):
+    suffix = _unique()
+    req = ticketing.requests.create(
+        subject=f"libzapi request {suffix}",
+        comment={"body": "created by libzapi"},
+    )
+    assert req.id > 0
+
+    updated = ticketing.requests.update(
+        req.id, comment={"body": "updated via libzapi", "public": False}
+    )
+    assert updated.id == req.id
+
+    solved = ticketing.requests.update(req.id, solved=True)
+    assert solved.status == "solved"
+
+
+def test_list_comments(ticketing: Ticketing):
+    req = ticketing.requests.create(
+        subject=f"libzapi comments {_unique()}",
+        comment={"body": "first comment"},
+    )
+    comments = list(ticketing.requests.list_comments(req.id))
+    assert len(comments) >= 1
+    first = ticketing.requests.get_comment(req.id, comments[0]["id"])
+    assert first["id"] == comments[0]["id"]

--- a/tests/unit/ticketing/test_request_client.py
+++ b/tests/unit/ticketing/test_request_client.py
@@ -1,0 +1,104 @@
+import pytest
+
+from libzapi.application.commands.ticketing.request_cmds import (
+    CreateRequestCmd,
+    UpdateRequestCmd,
+)
+from libzapi.infrastructure.api_clients.ticketing.request_api_client import (
+    RequestApiClient,
+)
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.request_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+@pytest.fixture
+def yield_items(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.request_api_client.yield_items"
+    )
+
+
+def test_list_yields_items(http, domain, yield_items):
+    yield_items.return_value = iter([{"id": 1}])
+    client = RequestApiClient(http)
+    result = list(client.list())
+    assert result[0]["_cls"] == "Request"
+    kwargs = yield_items.call_args.kwargs
+    assert kwargs["first_path"] == "/api/v2/requests"
+    assert kwargs["items_key"] == "requests"
+
+
+def test_list_user_yields_items(http, domain, yield_items):
+    yield_items.return_value = iter([{"id": 1}])
+    client = RequestApiClient(http)
+    result = list(client.list_user(user_id=5))
+    assert result[0]["_cls"] == "Request"
+    kwargs = yield_items.call_args.kwargs
+    assert kwargs["first_path"] == "/api/v2/users/5/requests"
+
+
+def test_search_yields_items_and_encodes_query(http, domain, yield_items):
+    yield_items.return_value = iter([{"id": 1}])
+    client = RequestApiClient(http)
+    result = list(client.search(query="hello world"))
+    assert result[0]["_cls"] == "Request"
+    kwargs = yield_items.call_args.kwargs
+    assert kwargs["first_path"] == "/api/v2/requests/search?query=hello%20world"
+
+
+def test_get_reads_request_key(http, domain):
+    http.get.return_value = {"request": {"id": 7, "subject": "S"}}
+    client = RequestApiClient(http)
+    result = client.get(request_id=7)
+    http.get.assert_called_with("/api/v2/requests/7")
+    assert result["_cls"] == "Request"
+
+
+def test_create_posts_payload(http, domain):
+    http.post.return_value = {"request": {"id": 1, "subject": "S"}}
+    client = RequestApiClient(http)
+    client.create(CreateRequestCmd(subject="S", comment={"body": "hi"}))
+    http.post.assert_called_with(
+        "/api/v2/requests",
+        {"request": {"subject": "S", "comment": {"body": "hi"}}},
+    )
+
+
+def test_update_puts_payload(http, domain):
+    http.put.return_value = {"request": {"id": 1, "status": "solved"}}
+    client = RequestApiClient(http)
+    client.update(request_id=1, entity=UpdateRequestCmd(solved=True))
+    http.put.assert_called_with(
+        "/api/v2/requests/1", {"request": {"solved": True}}
+    )
+
+
+def test_list_comments_yields_items(http, yield_items):
+    yield_items.return_value = iter([{"id": 1}, {"id": 2}])
+    client = RequestApiClient(http)
+    result = list(client.list_comments(request_id=7))
+    assert [c["id"] for c in result] == [1, 2]
+    kwargs = yield_items.call_args.kwargs
+    assert kwargs["first_path"] == "/api/v2/requests/7/comments"
+    assert kwargs["items_key"] == "comments"
+
+
+def test_get_comment_reads_comment_key(http):
+    http.get.return_value = {"comment": {"id": 9, "body": "hi"}}
+    client = RequestApiClient(http)
+    result = client.get_comment(request_id=7, comment_id=9)
+    http.get.assert_called_with("/api/v2/requests/7/comments/9")
+    assert result == {"id": 9, "body": "hi"}

--- a/tests/unit/ticketing/test_request_mapper.py
+++ b/tests/unit/ticketing/test_request_mapper.py
@@ -1,0 +1,105 @@
+from libzapi.application.commands.ticketing.request_cmds import (
+    CreateRequestCmd,
+    UpdateRequestCmd,
+)
+from libzapi.infrastructure.mappers.ticketing.request_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
+
+
+def test_create_minimal_payload():
+    payload = to_payload_create(
+        CreateRequestCmd(subject="S", comment={"body": "hi"})
+    )
+    assert payload == {
+        "request": {"subject": "S", "comment": {"body": "hi"}}
+    }
+
+
+def test_create_includes_all_fields():
+    payload = to_payload_create(
+        CreateRequestCmd(
+            subject="S",
+            comment={"body": "hi"},
+            requester={"name": "A", "email": "a@x"},
+            priority="high",
+            type="question",
+            custom_fields=[{"id": 1, "value": "v"}],
+            ticket_form_id=9,
+            recipient="r@x",
+            collaborators=[1, 2],
+            email_ccs=[{"user_id": 3}],
+            due_at="2030-01-01T00:00Z",
+        )
+    )
+    body = payload["request"]
+    assert body["subject"] == "S"
+    assert body["requester"] == {"name": "A", "email": "a@x"}
+    assert body["priority"] == "high"
+    assert body["type"] == "question"
+    assert body["custom_fields"] == [{"id": 1, "value": "v"}]
+    assert body["ticket_form_id"] == 9
+    assert body["recipient"] == "r@x"
+    assert body["collaborators"] == [1, 2]
+    assert body["email_ccs"] == [{"user_id": 3}]
+    assert body["due_at"] == "2030-01-01T00:00Z"
+
+
+def test_create_converts_custom_fields_iterable():
+    payload = to_payload_create(
+        CreateRequestCmd(
+            subject="S",
+            comment={"body": "hi"},
+            custom_fields=iter([{"id": 1, "value": "v"}]),
+        )
+    )
+    assert payload["request"]["custom_fields"] == [{"id": 1, "value": "v"}]
+
+
+def test_create_converts_collaborators_iterable():
+    payload = to_payload_create(
+        CreateRequestCmd(
+            subject="S", comment={"body": "hi"}, collaborators=iter([1])
+        )
+    )
+    assert payload["request"]["collaborators"] == [1]
+
+
+def test_update_empty_patch():
+    assert to_payload_update(UpdateRequestCmd()) == {"request": {}}
+
+
+def test_update_includes_all_fields():
+    payload = to_payload_update(
+        UpdateRequestCmd(
+            comment={"body": "hi", "public": True},
+            solved=True,
+            additional_collaborators=[5],
+            email_ccs=[{"user_id": 3}],
+        )
+    )
+    assert payload == {
+        "request": {
+            "comment": {"body": "hi", "public": True},
+            "solved": True,
+            "additional_collaborators": [5],
+            "email_ccs": [{"user_id": 3}],
+        }
+    }
+
+
+def test_update_preserves_false_solved():
+    payload = to_payload_update(UpdateRequestCmd(solved=False))
+    assert payload["request"]["solved"] is False
+
+
+def test_update_converts_iterables():
+    payload = to_payload_update(
+        UpdateRequestCmd(
+            additional_collaborators=iter([1]),
+            email_ccs=iter([{"user_id": 2}]),
+        )
+    )
+    assert payload["request"]["additional_collaborators"] == [1]
+    assert payload["request"]["email_ccs"] == [{"user_id": 2}]

--- a/tests/unit/ticketing/test_requests_service.py
+++ b/tests/unit/ticketing/test_requests_service.py
@@ -1,0 +1,111 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.commands.ticketing.request_cmds import (
+    CreateRequestCmd,
+    UpdateRequestCmd,
+)
+from libzapi.application.services.ticketing.requests_service import (
+    RequestsService,
+)
+from libzapi.domain.errors import (
+    NotFound,
+    RateLimited,
+    Unauthorized,
+    UnprocessableEntity,
+)
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return RequestsService(client), client
+
+
+class TestDelegation:
+    def test_list_all_delegates(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.items
+        assert service.list_all() is sentinel.items
+
+    def test_list_by_user_delegates(self):
+        service, client = _make_service()
+        client.list_user.return_value = sentinel.items
+        assert service.list_by_user(5) is sentinel.items
+        client.list_user.assert_called_once_with(5)
+
+    def test_search_delegates(self):
+        service, client = _make_service()
+        client.search.return_value = sentinel.items
+        assert service.search("q") is sentinel.items
+        client.search.assert_called_once_with("q")
+
+    def test_get_by_id_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.item
+        assert service.get_by_id(7) is sentinel.item
+        client.get.assert_called_once_with(7)
+
+    def test_list_comments_delegates(self):
+        service, client = _make_service()
+        client.list_comments.return_value = sentinel.items
+        assert service.list_comments(7) is sentinel.items
+        client.list_comments.assert_called_once_with(7)
+
+    def test_get_comment_delegates(self):
+        service, client = _make_service()
+        client.get_comment.return_value = sentinel.item
+        assert service.get_comment(7, 9) is sentinel.item
+        client.get_comment.assert_called_once_with(request_id=7, comment_id=9)
+
+
+class TestCreate:
+    def test_builds_create_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.create.return_value = sentinel.req
+
+        result = service.create(subject="S", comment={"body": "hi"})
+
+        cmd = client.create.call_args.kwargs["entity"]
+        assert isinstance(cmd, CreateRequestCmd)
+        assert cmd.subject == "S"
+        assert cmd.comment == {"body": "hi"}
+        assert result is sentinel.req
+
+
+class TestUpdate:
+    def test_builds_update_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.update.return_value = sentinel.req
+
+        result = service.update(7, solved=True)
+
+        assert client.update.call_args.kwargs["request_id"] == 7
+        cmd = client.update.call_args.kwargs["entity"]
+        assert isinstance(cmd, UpdateRequestCmd)
+        assert cmd.solved is True
+        assert result is sentinel.req
+
+    def test_empty_fields_yields_blank_cmd(self):
+        service, client = _make_service()
+        service.update(1)
+        cmd = client.update.call_args.kwargs["entity"]
+        assert cmd.comment is None
+        assert cmd.solved is None
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize(
+        "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+    )
+    def test_create_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.create.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.create(subject="S", comment={"body": "hi"})
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_all_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.list.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list_all()


### PR DESCRIPTION
## Summary
- Adds list (all), search, create, update (comment/solve), list_comments and get_comment on Zendesk Requests.
- New `Create/Update` command dataclasses and payload mappers (preserves `false` solved, skips `None`, converts iterables to lists).
- Extends `RequestApiClient` and `RequestsService`.

Refs #79.

## Test plan
- [x] `uv run --python 3.12 pytest tests/unit/` — 1885 passed
- [x] 100% coverage across request_cmds / request_mapper / request_api_client / requests_service / request domain model
- [ ] Live integration tests on a real tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)