### PR TITLE
feat(ticketing): attachments upload/delete + redact

### DIFF
--- a/libzapi/application/services/ticketing/attachments_service.py
+++ b/libzapi/application/services/ticketing/attachments_service.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from libzapi.domain.models.ticketing.attachment import Attachment
+from libzapi.domain.models.ticketing.upload import Upload
 from libzapi.infrastructure.api_clients.ticketing import AttachmentApiClient
 
 
@@ -10,3 +13,20 @@ class AttachmentsService:
 
     def get(self, attachment_id: int) -> Attachment:
         return self._client.get(attachment_id=attachment_id)
+
+    def delete(self, attachment_id: int) -> None:
+        self._client.delete(attachment_id=attachment_id)
+
+    def redact(self, attachment_id: int) -> Attachment:
+        return self._client.redact(attachment_id=attachment_id)
+
+    def upload(
+        self,
+        file: tuple,
+        filename: str | None = None,
+        token: str | None = None,
+    ) -> Upload:
+        return self._client.upload(file=file, filename=filename, token=token)
+
+    def delete_upload(self, token: str) -> None:
+        self._client.delete_upload(token=token)

--- a/libzapi/domain/models/ticketing/upload.py
+++ b/libzapi/domain/models/ticketing/upload.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import List
+
+from libzapi.domain.models.ticketing.attachment import Attachment
+from libzapi.domain.shared_objects.logical_key import LogicalKey
+
+
+@dataclass(frozen=True, slots=True)
+class Upload:
+    token: str
+    attachment: Attachment
+    attachments: List[Attachment]
+
+    @property
+    def logical_key(self) -> LogicalKey:
+        return LogicalKey("upload", self.token)

--- a/libzapi/infrastructure/api_clients/ticketing/attachment_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/attachment_api_client.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
+from urllib.parse import quote
+
 from libzapi.domain.models.ticketing.attachment import Attachment
+from libzapi.domain.models.ticketing.upload import Upload
 from libzapi.infrastructure.http.client import HttpClient
 from libzapi.infrastructure.serialization.parse import to_domain
 
 
 class AttachmentApiClient:
-    """HTTP adapter for Zendesk Attachments API."""
+    """HTTP adapter for Zendesk Attachments and Uploads."""
 
     def __init__(self, http: HttpClient) -> None:
         self._http = http
@@ -14,3 +17,30 @@ class AttachmentApiClient:
     def get(self, attachment_id: int) -> Attachment:
         data = self._http.get(f"/api/v2/attachments/{int(attachment_id)}")
         return to_domain(data=data["attachment"], cls=Attachment)
+
+    def delete(self, attachment_id: int) -> None:
+        self._http.delete(f"/api/v2/attachments/{int(attachment_id)}")
+
+    def redact(self, attachment_id: int) -> Attachment:
+        data = self._http.put(
+            f"/api/v2/attachments/{int(attachment_id)}/redact", {}
+        )
+        return to_domain(data=data["attachment"], cls=Attachment)
+
+    def upload(
+        self,
+        file: tuple,
+        filename: str | None = None,
+        token: str | None = None,
+    ) -> Upload:
+        name = filename or file[0]
+        path = f"/api/v2/uploads?filename={quote(name)}"
+        if token:
+            path += f"&token={quote(token)}"
+        data = self._http.post_multipart(
+            path, files={"uploaded_data": file}
+        )
+        return to_domain(data=data["upload"], cls=Upload)
+
+    def delete_upload(self, token: str) -> None:
+        self._http.delete(f"/api/v2/uploads/{quote(token)}")

--- a/tests/integration/ticketing/test_attachment.py
+++ b/tests/integration/ticketing/test_attachment.py
@@ -1,0 +1,36 @@
+import uuid
+
+from libzapi import Ticketing
+
+
+def _unique() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+def test_upload_and_delete_upload(ticketing: Ticketing):
+    suffix = _unique()
+    filename = f"libzapi-{suffix}.txt"
+    upload = ticketing.attachments.upload(
+        file=(filename, b"libzapi integration test", "text/plain")
+    )
+    try:
+        assert upload.token
+        assert upload.attachment.file_name == filename
+    finally:
+        ticketing.attachments.delete_upload(upload.token)
+
+
+def test_upload_append_to_existing_token(ticketing: Ticketing):
+    suffix = _unique()
+    first = ticketing.attachments.upload(
+        file=(f"first-{suffix}.txt", b"one", "text/plain")
+    )
+    try:
+        second = ticketing.attachments.upload(
+            file=(f"second-{suffix}.txt", b"two", "text/plain"),
+            token=first.token,
+        )
+        assert second.token == first.token
+        assert len(second.attachments) >= 2
+    finally:
+        ticketing.attachments.delete_upload(first.token)

--- a/tests/unit/ticketing/test_attachment_client.py
+++ b/tests/unit/ticketing/test_attachment_client.py
@@ -1,0 +1,96 @@
+import pytest
+
+from libzapi.infrastructure.api_clients.ticketing.attachment_api_client import (
+    AttachmentApiClient,
+)
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.attachment_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+def test_get_reads_attachment_key(http, domain):
+    http.get.return_value = {"attachment": {"id": 7}}
+    client = AttachmentApiClient(http)
+    result = client.get(attachment_id=7)
+    http.get.assert_called_with("/api/v2/attachments/7")
+    assert result["_cls"] == "Attachment"
+
+
+def test_delete_calls_delete(http):
+    client = AttachmentApiClient(http)
+    client.delete(attachment_id=9)
+    http.delete.assert_called_with("/api/v2/attachments/9")
+
+
+def test_redact_puts_empty_body(http, domain):
+    http.put.return_value = {"attachment": {"id": 9}}
+    client = AttachmentApiClient(http)
+    result = client.redact(attachment_id=9)
+    http.put.assert_called_with("/api/v2/attachments/9/redact", {})
+    assert result["_cls"] == "Attachment"
+
+
+def test_upload_posts_multipart_with_filename(http, domain):
+    http.post_multipart.return_value = {
+        "upload": {
+            "token": "abc",
+            "attachment": {"id": 1},
+            "attachments": [{"id": 1}],
+        }
+    }
+    client = AttachmentApiClient(http)
+    file = ("hello.txt", b"payload", "text/plain")
+    result = client.upload(file=file)
+
+    call = http.post_multipart.call_args
+    assert call.args[0] == "/api/v2/uploads?filename=hello.txt"
+    assert call.kwargs["files"] == {"uploaded_data": file}
+    assert result["_cls"] == "Upload"
+    assert result["token"] == "abc"
+
+
+def test_upload_overrides_filename(http, domain):
+    http.post_multipart.return_value = {
+        "upload": {
+            "token": "abc",
+            "attachment": {"id": 1},
+            "attachments": [{"id": 1}],
+        }
+    }
+    client = AttachmentApiClient(http)
+    file = ("hello.txt", b"x", "text/plain")
+    client.upload(file=file, filename="override name.txt")
+    call = http.post_multipart.call_args
+    assert call.args[0] == "/api/v2/uploads?filename=override%20name.txt"
+
+
+def test_upload_appends_token_to_existing_upload(http, domain):
+    http.post_multipart.return_value = {
+        "upload": {
+            "token": "abc",
+            "attachment": {"id": 2},
+            "attachments": [{"id": 2}],
+        }
+    }
+    client = AttachmentApiClient(http)
+    client.upload(file=("b.bin", b"y"), token="abc")
+    call = http.post_multipart.call_args
+    assert call.args[0] == "/api/v2/uploads?filename=b.bin&token=abc"
+
+
+def test_delete_upload_calls_delete_with_token(http):
+    client = AttachmentApiClient(http)
+    client.delete_upload(token="abc-def")
+    http.delete.assert_called_with("/api/v2/uploads/abc-def")

--- a/tests/unit/ticketing/test_attachments_service.py
+++ b/tests/unit/ticketing/test_attachments_service.py
@@ -1,0 +1,64 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.services.ticketing.attachments_service import (
+    AttachmentsService,
+)
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return AttachmentsService(client), client
+
+
+class TestDelegation:
+    def test_get_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.att
+        assert service.get(7) is sentinel.att
+        client.get.assert_called_once_with(attachment_id=7)
+
+    def test_delete_delegates(self):
+        service, client = _make_service()
+        service.delete(5)
+        client.delete.assert_called_once_with(attachment_id=5)
+
+    def test_redact_delegates(self):
+        service, client = _make_service()
+        client.redact.return_value = sentinel.att
+        assert service.redact(5) is sentinel.att
+        client.redact.assert_called_once_with(attachment_id=5)
+
+    def test_upload_delegates(self):
+        service, client = _make_service()
+        client.upload.return_value = sentinel.upload
+        file = ("f.txt", b"x", "text/plain")
+
+        result = service.upload(file=file, filename="n", token="t")
+
+        assert result is sentinel.upload
+        client.upload.assert_called_once_with(
+            file=file, filename="n", token="t"
+        )
+
+    def test_delete_upload_delegates(self):
+        service, client = _make_service()
+        service.delete_upload("abc")
+        client.delete_upload.assert_called_once_with(token="abc")
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_upload_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.upload.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.upload(file=("f.txt", b"x"))
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_get_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.get.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.get(1)

--- a/tests/unit/ticketing/test_upload.py
+++ b/tests/unit/ticketing/test_upload.py
@@ -1,0 +1,19 @@
+from hypothesis import given
+from hypothesis.strategies import just, builds
+
+from libzapi.domain.models.ticketing.attachment import Attachment
+from libzapi.domain.models.ticketing.upload import Upload
+
+
+attachment_strategy = builds(Attachment, file_name=just("f.png"))
+upload_strategy = builds(
+    Upload,
+    token=just("abc-token"),
+    attachment=attachment_strategy,
+    attachments=just([]),
+)
+
+
+@given(upload_strategy)
+def test_upload_logical_key_uses_token(upload: Upload) -> None:
+    assert upload.logical_key.as_str() == "upload:abc-token"


### PR DESCRIPTION
## Summary
- Adds `upload` (multipart, with optional token chaining for multi-file uploads), `delete_upload`, `delete`, and `redact` on ticketing attachments.
- New `Upload` domain model wrapping `{token, attachment, attachments[]}`.
- Extends `AttachmentApiClient` and `AttachmentsService`.

Refs #79.

## Test plan
- [x] `uv run --python 3.12 pytest tests/unit/` — 1871 passed
- [x] 100% coverage across attachment/upload domain models, attachment_api_client, attachments_service
- [ ] Live integration tests on a real tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)