### PR TITLE
feat(ticketing): sessions delete + current/logout

### DIFF
--- a/libzapi/application/services/ticketing/sessions_service.py
+++ b/libzapi/application/services/ticketing/sessions_service.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 from typing import Iterable
 
 from libzapi.domain.models.ticketing.sessions import Session
-from libzapi.infrastructure.api_clients.ticketing.session_api_client import SessionApiClient
+from libzapi.infrastructure.api_clients.ticketing.session_api_client import (
+    SessionApiClient,
+)
 
 
 class SessionsService:
@@ -18,3 +22,15 @@ class SessionsService:
 
     def get(self, user_id: int, session_id: int) -> Session:
         return self._client.get(user_id=user_id, session_id=session_id)
+
+    def delete(self, user_id: int, session_id: int) -> None:
+        self._client.delete(user_id=user_id, session_id=session_id)
+
+    def delete_user_sessions(self, user_id: int) -> None:
+        self._client.delete_user_sessions(user_id=user_id)
+
+    def get_current(self) -> Session:
+        return self._client.get_current()
+
+    def logout_current(self) -> None:
+        self._client.logout_current()

--- a/libzapi/infrastructure/api_clients/ticketing/session_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/session_api_client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterator
 
 from libzapi.domain.models.ticketing.sessions import Session
 from libzapi.infrastructure.http.client import HttpClient
@@ -9,12 +9,12 @@ from libzapi.infrastructure.serialization.parse import to_domain
 
 
 class SessionApiClient:
-    """HTTP adapter for Zendesk Workspace"""
+    """HTTP adapter for Zendesk Sessions."""
 
     def __init__(self, http: HttpClient) -> None:
         self._http = http
 
-    def list(self) -> Iterable[Session]:
+    def list(self) -> Iterator[Session]:
         for obj in yield_items(
             get_json=self._http.get,
             first_path="/api/v2/sessions",
@@ -23,15 +23,32 @@ class SessionApiClient:
         ):
             yield to_domain(data=obj, cls=Session)
 
-    def list_user(self, user_id) -> Iterable[Session]:
+    def list_user(self, user_id: int) -> Iterator[Session]:
         for obj in yield_items(
             get_json=self._http.get,
-            first_path=f"/api/v2/users/{user_id}/sessions",
+            first_path=f"/api/v2/users/{int(user_id)}/sessions",
             base_url=self._http.base_url,
             items_key="sessions",
         ):
             yield to_domain(data=obj, cls=Session)
 
     def get(self, user_id: int, session_id: int) -> Session:
-        data = self._http.get(f"/api/v2/users/{int(user_id)}/sessions/{int(session_id)}")
+        data = self._http.get(
+            f"/api/v2/users/{int(user_id)}/sessions/{int(session_id)}"
+        )
         return to_domain(data=data["session"], cls=Session)
+
+    def delete(self, user_id: int, session_id: int) -> None:
+        self._http.delete(
+            f"/api/v2/users/{int(user_id)}/sessions/{int(session_id)}"
+        )
+
+    def delete_user_sessions(self, user_id: int) -> None:
+        self._http.delete(f"/api/v2/users/{int(user_id)}/sessions")
+
+    def get_current(self) -> Session:
+        data = self._http.get("/api/v2/users/me/session")
+        return to_domain(data=data["session"], cls=Session)
+
+    def logout_current(self) -> None:
+        self._http.delete("/api/v2/users/me/logout")

--- a/tests/integration/ticketing/test_session.py
+++ b/tests/integration/ticketing/test_session.py
@@ -1,0 +1,23 @@
+import itertools
+
+from libzapi import Ticketing
+
+
+def test_list_sessions(ticketing: Ticketing):
+    sessions = list(itertools.islice(ticketing.sessions.list(), 5))
+    assert isinstance(sessions, list)
+
+
+def test_get_current_session(ticketing: Ticketing):
+    session = ticketing.sessions.get_current()
+    assert session.id > 0
+
+
+def test_list_by_user(ticketing: Ticketing):
+    current = ticketing.sessions.get_current()
+    sessions = list(
+        itertools.islice(
+            ticketing.sessions.list_user(current.user_id), 5
+        )
+    )
+    assert isinstance(sessions, list)

--- a/tests/unit/ticketing/test_session_client.py
+++ b/tests/unit/ticketing/test_session_client.py
@@ -1,0 +1,80 @@
+import pytest
+
+from libzapi.infrastructure.api_clients.ticketing.session_api_client import (
+    SessionApiClient,
+)
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.session_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+@pytest.fixture
+def yield_items(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.session_api_client.yield_items"
+    )
+
+
+def test_list_yields_items(http, domain, yield_items):
+    yield_items.return_value = iter([{"id": 1}])
+    client = SessionApiClient(http)
+    result = list(client.list())
+    assert result[0]["_cls"] == "Session"
+    kwargs = yield_items.call_args.kwargs
+    assert kwargs["first_path"] == "/api/v2/sessions"
+    assert kwargs["items_key"] == "sessions"
+
+
+def test_list_user_yields_items(http, domain, yield_items):
+    yield_items.return_value = iter([{"id": 1}])
+    client = SessionApiClient(http)
+    result = list(client.list_user(user_id=5))
+    assert result[0]["_cls"] == "Session"
+    kwargs = yield_items.call_args.kwargs
+    assert kwargs["first_path"] == "/api/v2/users/5/sessions"
+
+
+def test_get_reads_session_key(http, domain):
+    http.get.return_value = {"session": {"id": 7}}
+    client = SessionApiClient(http)
+    result = client.get(user_id=5, session_id=7)
+    http.get.assert_called_with("/api/v2/users/5/sessions/7")
+    assert result["_cls"] == "Session"
+
+
+def test_delete_calls_delete(http):
+    client = SessionApiClient(http)
+    client.delete(user_id=5, session_id=7)
+    http.delete.assert_called_with("/api/v2/users/5/sessions/7")
+
+
+def test_delete_user_sessions_calls_delete(http):
+    client = SessionApiClient(http)
+    client.delete_user_sessions(user_id=5)
+    http.delete.assert_called_with("/api/v2/users/5/sessions")
+
+
+def test_get_current_reads_session_key(http, domain):
+    http.get.return_value = {"session": {"id": 9}}
+    client = SessionApiClient(http)
+    result = client.get_current()
+    http.get.assert_called_with("/api/v2/users/me/session")
+    assert result["_cls"] == "Session"
+
+
+def test_logout_current_calls_delete(http):
+    client = SessionApiClient(http)
+    client.logout_current()
+    http.delete.assert_called_with("/api/v2/users/me/logout")

--- a/tests/unit/ticketing/test_sessions_service.py
+++ b/tests/unit/ticketing/test_sessions_service.py
@@ -1,0 +1,67 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.services.ticketing.sessions_service import (
+    SessionsService,
+)
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return SessionsService(client), client
+
+
+class TestDelegation:
+    def test_list_delegates(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.items
+        assert service.list() is sentinel.items
+
+    def test_list_user_delegates(self):
+        service, client = _make_service()
+        client.list_user.return_value = sentinel.items
+        assert service.list_user(5) is sentinel.items
+        client.list_user.assert_called_once_with(user_id=5)
+
+    def test_get_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.session
+        assert service.get(5, 7) is sentinel.session
+        client.get.assert_called_once_with(user_id=5, session_id=7)
+
+    def test_delete_delegates(self):
+        service, client = _make_service()
+        service.delete(5, 7)
+        client.delete.assert_called_once_with(user_id=5, session_id=7)
+
+    def test_delete_user_sessions_delegates(self):
+        service, client = _make_service()
+        service.delete_user_sessions(5)
+        client.delete_user_sessions.assert_called_once_with(user_id=5)
+
+    def test_get_current_delegates(self):
+        service, client = _make_service()
+        client.get_current.return_value = sentinel.session
+        assert service.get_current() is sentinel.session
+
+    def test_logout_current_delegates(self):
+        service, client = _make_service()
+        service.logout_current()
+        client.logout_current.assert_called_once_with()
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.list.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list()
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_get_current_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.get_current.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.get_current()


### PR DESCRIPTION
## Summary
- Adds `delete` (single), bulk `delete_user_sessions`, `get_current` (current-user session), and `logout_current` on sessions.
- Extends `SessionApiClient` and `SessionsService`.

Refs #79.

## Test plan
- [x] `uv run --python 3.12 pytest tests/unit/` — 1872 passed
- [x] 100% coverage across session_api_client / sessions_service / session domain model
- [ ] Live integration tests on a real tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)