### PR TITLE
feat(ticketing): unified search (search/count/export)

### DIFF
--- a/libzapi/application/services/ticketing/__init__.py
+++ b/libzapi/application/services/ticketing/__init__.py
@@ -13,6 +13,7 @@ from libzapi.application.services.ticketing.macro_service import MacroService
 from libzapi.application.services.ticketing.organizations_service import OrganizationsService
 from libzapi.application.services.ticketing.requests_service import RequestsService
 from libzapi.application.services.ticketing.schedule_service import ScheduleService
+from libzapi.application.services.ticketing.search_service import SearchService
 from libzapi.application.services.ticketing.sessions_service import SessionsService
 from libzapi.application.services.ticketing.sla_policies_service import SlaPoliciesService
 from libzapi.application.services.ticketing.support_addresses_service import SupportAddressesService
@@ -58,6 +59,7 @@ class Ticketing:
         self.organizations = OrganizationsService(api.OrganizationApiClient(http))
         self.requests = RequestsService(api.RequestApiClient(http))
         self.schedules = ScheduleService(api.ScheduleApiClient(http))
+        self.search = SearchService(api.SearchApiClient(http))
         self.sessions = SessionsService(api.SessionApiClient(http))
         self.sla_policies = SlaPoliciesService(api.SlaPolicyApiClient(http))
         self.support_addresses = SupportAddressesService(api.SupportAddressApiClient(http))

--- a/libzapi/application/services/ticketing/search_service.py
+++ b/libzapi/application/services/ticketing/search_service.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+from libzapi.infrastructure.api_clients.ticketing.search_api_client import (
+    SearchApiClient,
+)
+
+
+class SearchService:
+    """High-level service for Zendesk unified Search."""
+
+    def __init__(self, client: SearchApiClient) -> None:
+        self._client = client
+
+    def search(
+        self,
+        query: str,
+        *,
+        sort_by: str | None = None,
+        sort_order: str | None = None,
+    ) -> Iterator[dict]:
+        return self._client.search(
+            query=query, sort_by=sort_by, sort_order=sort_order
+        )
+
+    def count(self, query: str) -> int:
+        return self._client.count(query=query)
+
+    def export(
+        self,
+        query: str,
+        *,
+        filter_type: str,
+        page_size: int | None = None,
+    ) -> Iterator[dict]:
+        return self._client.export(
+            query=query, filter_type=filter_type, page_size=page_size
+        )

--- a/libzapi/infrastructure/api_clients/ticketing/__init__.py
+++ b/libzapi/infrastructure/api_clients/ticketing/__init__.py
@@ -12,6 +12,7 @@ from libzapi.infrastructure.api_clients.ticketing.macro_api_client import MacroA
 from libzapi.infrastructure.api_clients.ticketing.organization_api_client import OrganizationApiClient
 from libzapi.infrastructure.api_clients.ticketing.request_api_client import RequestApiClient
 from libzapi.infrastructure.api_clients.ticketing.schedule_api_client import ScheduleApiClient
+from libzapi.infrastructure.api_clients.ticketing.search_api_client import SearchApiClient
 from libzapi.infrastructure.api_clients.ticketing.session_api_client import SessionApiClient
 from libzapi.infrastructure.api_clients.ticketing.sla_policy_api_client import SlaPolicyApiClient
 from libzapi.infrastructure.api_clients.ticketing.suspended_ticket_api_client import SuspendedTicketApiClient
@@ -44,6 +45,7 @@ __all__ = [
     "OrganizationApiClient",
     "RequestApiClient",
     "ScheduleApiClient",
+    "SearchApiClient",
     "SessionApiClient",
     "SlaPolicyApiClient",
     "SupportAddressApiClient",

--- a/libzapi/infrastructure/api_clients/ticketing/search_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/search_api_client.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from typing import Iterator
+from urllib.parse import urlencode
+
+from libzapi.infrastructure.http.client import HttpClient
+from libzapi.infrastructure.http.pagination import yield_items
+
+
+def _qs(query: str, **extra: str | None) -> str:
+    params: dict[str, str] = {"query": query}
+    params.update({k: v for k, v in extra.items() if v is not None})
+    return urlencode(params)
+
+
+class SearchApiClient:
+    """HTTP adapter for Zendesk unified Search (ticket/user/org/group)."""
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def search(
+        self,
+        query: str,
+        *,
+        sort_by: str | None = None,
+        sort_order: str | None = None,
+    ) -> Iterator[dict]:
+        qs = _qs(query, sort_by=sort_by, sort_order=sort_order)
+        yield from yield_items(
+            get_json=self._http.get,
+            first_path=f"/api/v2/search?{qs}",
+            base_url=self._http.base_url,
+            items_key="results",
+        )
+
+    def count(self, query: str) -> int:
+        data = self._http.get(f"/api/v2/search/count?{_qs(query)}")
+        return int(data.get("count", 0))
+
+    def export(
+        self,
+        query: str,
+        *,
+        filter_type: str,
+        page_size: int | None = None,
+    ) -> Iterator[dict]:
+        qs = _qs(
+            query,
+            **{
+                "filter[type]": filter_type,
+                "page[size]": str(page_size) if page_size else None,
+            },
+        )
+        yield from yield_items(
+            get_json=self._http.get,
+            first_path=f"/api/v2/search/export?{qs}",
+            base_url=self._http.base_url,
+            items_key="results",
+        )

--- a/tests/integration/ticketing/test_search.py
+++ b/tests/integration/ticketing/test_search.py
@@ -1,0 +1,36 @@
+import itertools
+
+from libzapi import Ticketing
+
+
+def test_search_returns_results(ticketing: Ticketing):
+    hits = list(itertools.islice(ticketing.search.search("type:ticket"), 5))
+    assert isinstance(hits, list)
+
+
+def test_search_sort_params(ticketing: Ticketing):
+    hits = list(
+        itertools.islice(
+            ticketing.search.search(
+                "type:ticket", sort_by="created_at", sort_order="desc"
+            ),
+            5,
+        )
+    )
+    assert isinstance(hits, list)
+
+
+def test_count_returns_int(ticketing: Ticketing):
+    count = ticketing.search.count("type:user")
+    assert isinstance(count, int)
+    assert count >= 0
+
+
+def test_export_returns_typed_items(ticketing: Ticketing):
+    hits = list(
+        itertools.islice(
+            ticketing.search.export("type:ticket", filter_type="ticket"),
+            5,
+        )
+    )
+    assert isinstance(hits, list)

--- a/tests/unit/ticketing/test_search_client.py
+++ b/tests/unit/ticketing/test_search_client.py
@@ -1,0 +1,79 @@
+import pytest
+
+from libzapi.infrastructure.api_clients.ticketing.search_api_client import (
+    SearchApiClient,
+)
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def yield_items(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.search_api_client.yield_items"
+    )
+
+
+def test_search_yields_results(http, yield_items):
+    yield_items.return_value = iter([{"id": 1}, {"id": 2}])
+    client = SearchApiClient(http)
+    result = list(client.search(query="status:open"))
+    assert [r["id"] for r in result] == [1, 2]
+    kwargs = yield_items.call_args.kwargs
+    assert kwargs["first_path"] == "/api/v2/search?query=status%3Aopen"
+    assert kwargs["items_key"] == "results"
+
+
+def test_search_includes_sort_params(http, yield_items):
+    yield_items.return_value = iter([])
+    client = SearchApiClient(http)
+    list(client.search(query="q", sort_by="created_at", sort_order="desc"))
+    kwargs = yield_items.call_args.kwargs
+    assert kwargs["first_path"] == (
+        "/api/v2/search?query=q&sort_by=created_at&sort_order=desc"
+    )
+
+
+def test_search_omits_none_sort_params(http, yield_items):
+    yield_items.return_value = iter([])
+    client = SearchApiClient(http)
+    list(client.search(query="q"))
+    kwargs = yield_items.call_args.kwargs
+    assert kwargs["first_path"] == "/api/v2/search?query=q"
+
+
+def test_count_returns_int(http):
+    http.get.return_value = {"count": 42}
+    client = SearchApiClient(http)
+    assert client.count(query="status:open") == 42
+    http.get.assert_called_with("/api/v2/search/count?query=status%3Aopen")
+
+
+def test_count_defaults_to_zero(http):
+    http.get.return_value = {}
+    client = SearchApiClient(http)
+    assert client.count(query="q") == 0
+
+
+def test_export_yields_results_with_filter_type(http, yield_items):
+    yield_items.return_value = iter([{"id": 1}])
+    client = SearchApiClient(http)
+    result = list(client.export(query="q", filter_type="ticket"))
+    assert result[0]["id"] == 1
+    kwargs = yield_items.call_args.kwargs
+    assert kwargs["first_path"] == (
+        "/api/v2/search/export?query=q&filter%5Btype%5D=ticket"
+    )
+
+
+def test_export_includes_page_size(http, yield_items):
+    yield_items.return_value = iter([])
+    client = SearchApiClient(http)
+    list(client.export(query="q", filter_type="user", page_size=100))
+    kwargs = yield_items.call_args.kwargs
+    assert "page%5Bsize%5D=100" in kwargs["first_path"]

--- a/tests/unit/ticketing/test_search_service.py
+++ b/tests/unit/ticketing/test_search_service.py
@@ -1,0 +1,57 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.services.ticketing.search_service import SearchService
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return SearchService(client), client
+
+
+class TestDelegation:
+    def test_search_delegates(self):
+        service, client = _make_service()
+        client.search.return_value = sentinel.items
+        assert service.search("q") is sentinel.items
+        client.search.assert_called_once_with(
+            query="q", sort_by=None, sort_order=None
+        )
+
+    def test_search_forwards_sort_params(self):
+        service, client = _make_service()
+        service.search("q", sort_by="created_at", sort_order="desc")
+        client.search.assert_called_once_with(
+            query="q", sort_by="created_at", sort_order="desc"
+        )
+
+    def test_count_delegates(self):
+        service, client = _make_service()
+        client.count.return_value = 42
+        assert service.count("q") == 42
+        client.count.assert_called_once_with(query="q")
+
+    def test_export_delegates(self):
+        service, client = _make_service()
+        client.export.return_value = sentinel.items
+        assert service.export("q", filter_type="ticket") is sentinel.items
+        client.export.assert_called_once_with(
+            query="q", filter_type="ticket", page_size=None
+        )
+
+    def test_export_forwards_page_size(self):
+        service, client = _make_service()
+        service.export("q", filter_type="user", page_size=500)
+        client.export.assert_called_once_with(
+            query="q", filter_type="user", page_size=500
+        )
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_search_propagates_client_error(self, error_cls):
+        service, client = _make_service()
+        client.search.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.search("q")


### PR DESCRIPTION
## Summary
- Adds `SearchApiClient` and `SearchService` covering `/api/v2/search`, `/api/v2/search/count` and cursor-paginated `/api/v2/search/export` (with `filter[type]` and `page[size]`).
- Wires `ticketing.search` into the `Ticketing` facade.
- Results are returned as raw dicts because unified search is intentionally heterogeneous (tickets/users/orgs/groups).

Refs #79.

## Test plan
- [x] `uv run --python 3.12 pytest tests/unit/` — 1868 passed
- [x] 100% coverage across search_api_client / search_service
- [ ] Live integration tests on a real tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)