### PR TITLE
feat(ticketing): add unified tags (account + ticket/user/org)

### DIFF
--- a/libzapi/application/services/ticketing/__init__.py
+++ b/libzapi/application/services/ticketing/__init__.py
@@ -17,6 +17,7 @@ from libzapi.application.services.ticketing.sessions_service import SessionsServ
 from libzapi.application.services.ticketing.sla_policies_service import SlaPoliciesService
 from libzapi.application.services.ticketing.support_addresses_service import SupportAddressesService
 from libzapi.application.services.ticketing.suspended_tickets_service import SuspendedTicketsService
+from libzapi.application.services.ticketing.tags_service import TagsService
 from libzapi.application.services.ticketing.tickets_service import TickestService
 from libzapi.application.services.ticketing.ticket_audits_service import TicketAuditsService
 from libzapi.application.services.ticketing.ticket_fields_service import TicketFieldsService
@@ -62,6 +63,7 @@ class Ticketing:
         self.sla_policies = SlaPoliciesService(api.SlaPolicyApiClient(http))
         self.support_addresses = SupportAddressesService(api.SupportAddressApiClient(http))
         self.suspended_tickets = SuspendedTicketsService(api.SuspendedTicketApiClient(http))
+        self.tags = TagsService(api.TagApiClient(http))
         self.tickets = TickestService(api.TicketApiClient(http))
         self.ticket_audits = TicketAuditsService(api.TicketAuditApiClient(http))
         self.ticket_fields = TicketFieldsService(api.TicketFieldApiClient(http))

--- a/libzapi/application/services/ticketing/tags_service.py
+++ b/libzapi/application/services/ticketing/tags_service.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+from libzapi.infrastructure.api_clients.ticketing.tag_api_client import TagApiClient
+
+
+class TagsService:
+    """High-level service for Zendesk tags (account + per-resource)."""
+
+    def __init__(self, client: TagApiClient) -> None:
+        self._client = client
+
+    def list_account(self) -> Iterator[dict]:
+        return self._client.list_account()
+
+    def list_for(self, resource: str, resource_id: int) -> list[str]:
+        return self._client.list_for(resource=resource, resource_id=resource_id)
+
+    def add(
+        self, resource: str, resource_id: int, tags: Iterable[str]
+    ) -> list[str]:
+        return self._client.add(
+            resource=resource, resource_id=resource_id, tags=tags
+        )
+
+    def set(
+        self, resource: str, resource_id: int, tags: Iterable[str]
+    ) -> list[str]:
+        return self._client.set(
+            resource=resource, resource_id=resource_id, tags=tags
+        )
+
+    def remove(
+        self, resource: str, resource_id: int, tags: Iterable[str]
+    ) -> list[str]:
+        return self._client.remove(
+            resource=resource, resource_id=resource_id, tags=tags
+        )

--- a/libzapi/infrastructure/api_clients/ticketing/__init__.py
+++ b/libzapi/infrastructure/api_clients/ticketing/__init__.py
@@ -16,6 +16,7 @@ from libzapi.infrastructure.api_clients.ticketing.session_api_client import Sess
 from libzapi.infrastructure.api_clients.ticketing.sla_policy_api_client import SlaPolicyApiClient
 from libzapi.infrastructure.api_clients.ticketing.suspended_ticket_api_client import SuspendedTicketApiClient
 from libzapi.infrastructure.api_clients.ticketing.support_address_api_client import SupportAddressApiClient
+from libzapi.infrastructure.api_clients.ticketing.tag_api_client import TagApiClient
 from libzapi.infrastructure.api_clients.ticketing.ticket_api_client import TicketApiClient
 from libzapi.infrastructure.api_clients.ticketing.ticket_audit_api_client import TicketAuditApiClient
 from libzapi.infrastructure.api_clients.ticketing.ticket_field_api_client import TicketFieldApiClient
@@ -48,6 +49,7 @@ __all__ = [
     "SlaPolicyApiClient",
     "SupportAddressApiClient",
     "SuspendedTicketApiClient",
+    "TagApiClient",
     "TicketApiClient",
     "TicketAuditApiClient",
     "TicketFieldApiClient",

--- a/libzapi/infrastructure/api_clients/ticketing/tag_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/tag_api_client.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+from libzapi.infrastructure.http.client import HttpClient
+from libzapi.infrastructure.http.pagination import yield_items
+
+
+_RESOURCE_PATHS = {
+    "ticket": "tickets",
+    "user": "users",
+    "organization": "organizations",
+}
+
+
+def _resource_path(resource: str, resource_id: int) -> str:
+    if resource not in _RESOURCE_PATHS:
+        raise ValueError(
+            f"resource must be one of {sorted(_RESOURCE_PATHS)!r}, got {resource!r}"
+        )
+    return f"/api/v2/{_RESOURCE_PATHS[resource]}/{int(resource_id)}/tags"
+
+
+class TagApiClient:
+    """HTTP adapter for Zendesk Tags (account + per-resource)."""
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def list_account(self) -> Iterator[dict]:
+        yield from yield_items(
+            get_json=self._http.get,
+            first_path="/api/v2/tags",
+            base_url=self._http.base_url,
+            items_key="tags",
+        )
+
+    def list_for(self, resource: str, resource_id: int) -> list[str]:
+        data = self._http.get(_resource_path(resource, resource_id))
+        return list(data.get("tags", []))
+
+    def add(
+        self, resource: str, resource_id: int, tags: Iterable[str]
+    ) -> list[str]:
+        data = self._http.put(
+            _resource_path(resource, resource_id), {"tags": list(tags)}
+        )
+        return list(data.get("tags", []))
+
+    def set(
+        self, resource: str, resource_id: int, tags: Iterable[str]
+    ) -> list[str]:
+        data = self._http.post(
+            _resource_path(resource, resource_id), {"tags": list(tags)}
+        )
+        return list(data.get("tags", []))
+
+    def remove(
+        self, resource: str, resource_id: int, tags: Iterable[str]
+    ) -> list[str]:
+        data = self._http.delete(
+            _resource_path(resource, resource_id),
+            json={"tags": list(tags)},
+        )
+        return list((data or {}).get("tags", []))

--- a/tests/integration/ticketing/test_tags.py
+++ b/tests/integration/ticketing/test_tags.py
@@ -1,0 +1,57 @@
+import itertools
+import uuid
+
+import pytest
+
+from libzapi import Ticketing
+
+
+def _unique() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+def _first_ticket_id(ticketing: Ticketing) -> int:
+    for ticket in itertools.islice(ticketing.tickets.list(), 50):
+        return ticket.id
+    pytest.skip("No tickets available to tag.")
+
+
+def test_list_account_tags(ticketing: Ticketing):
+    tags = list(itertools.islice(ticketing.tags.list_account(), 20))
+    assert isinstance(tags, list)
+    for tag in tags:
+        assert "name" in tag
+
+
+def test_list_for_ticket(ticketing: Ticketing):
+    ticket_id = _first_ticket_id(ticketing)
+    tags = ticketing.tags.list_for("ticket", ticket_id)
+    assert isinstance(tags, list)
+    for tag in tags:
+        assert isinstance(tag, str)
+
+
+def test_add_set_remove_lifecycle_ticket(ticketing: Ticketing):
+    ticket_id = _first_ticket_id(ticketing)
+    marker = f"libzapi_{_unique()}"
+    try:
+        added = ticketing.tags.add("ticket", ticket_id, [marker])
+        assert marker in added
+
+        replaced = ticketing.tags.set("ticket", ticket_id, [marker, f"{marker}_b"])
+        assert marker in replaced
+        assert f"{marker}_b" in replaced
+
+        removed = ticketing.tags.remove(
+            "ticket", ticket_id, [marker, f"{marker}_b"]
+        )
+        assert isinstance(removed, list)
+        assert marker not in removed
+        assert f"{marker}_b" not in removed
+    finally:
+        ticketing.tags.remove("ticket", ticket_id, [marker, f"{marker}_b"])
+
+
+def test_invalid_resource_raises(ticketing: Ticketing):
+    with pytest.raises(ValueError):
+        ticketing.tags.list_for("group", 1)

--- a/tests/unit/ticketing/test_tag_client.py
+++ b/tests/unit/ticketing/test_tag_client.py
@@ -1,0 +1,138 @@
+import pytest
+
+from libzapi.domain.errors import NotFound, Unauthorized
+from libzapi.infrastructure.api_clients.ticketing import TagApiClient
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def yield_items(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.tag_api_client.yield_items"
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_account
+# ---------------------------------------------------------------------------
+
+
+def test_list_account_delegates_to_yield_items(http, yield_items):
+    yield_items.return_value = iter([{"name": "a", "count": 1}])
+    client = TagApiClient(http)
+    out = list(client.list_account())
+    yield_items.assert_called_once_with(
+        get_json=http.get,
+        first_path="/api/v2/tags",
+        base_url=http.base_url,
+        items_key="tags",
+    )
+    assert out == [{"name": "a", "count": 1}]
+
+
+# ---------------------------------------------------------------------------
+# list_for
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "resource, path",
+    [
+        ("ticket", "/api/v2/tickets/42/tags"),
+        ("user", "/api/v2/users/42/tags"),
+        ("organization", "/api/v2/organizations/42/tags"),
+    ],
+)
+def test_list_for_resource_hits_expected_path(http, resource, path):
+    http.get.return_value = {"tags": ["foo", "bar"]}
+    client = TagApiClient(http)
+    result = client.list_for(resource=resource, resource_id=42)
+    http.get.assert_called_with(path)
+    assert result == ["foo", "bar"]
+
+
+def test_list_for_missing_tags_returns_empty_list(http):
+    http.get.return_value = {}
+    client = TagApiClient(http)
+    assert client.list_for(resource="ticket", resource_id=1) == []
+
+
+def test_invalid_resource_raises_value_error(http):
+    client = TagApiClient(http)
+    with pytest.raises(ValueError, match="resource must be one of"):
+        client.list_for(resource="group", resource_id=1)
+
+
+# ---------------------------------------------------------------------------
+# add / set / remove
+# ---------------------------------------------------------------------------
+
+
+def test_add_puts_tags_and_returns_list(http):
+    http.put.return_value = {"tags": ["foo", "bar", "baz"]}
+    client = TagApiClient(http)
+    result = client.add(resource="ticket", resource_id=42, tags=iter(["baz"]))
+    http.put.assert_called_with(
+        "/api/v2/tickets/42/tags", {"tags": ["baz"]}
+    )
+    assert result == ["foo", "bar", "baz"]
+
+
+def test_set_posts_tags_and_returns_list(http):
+    http.post.return_value = {"tags": ["only", "these"]}
+    client = TagApiClient(http)
+    result = client.set(resource="user", resource_id=7, tags=["only", "these"])
+    http.post.assert_called_with(
+        "/api/v2/users/7/tags", {"tags": ["only", "these"]}
+    )
+    assert result == ["only", "these"]
+
+
+def test_remove_deletes_with_json_body(http):
+    http.delete.return_value = {"tags": ["remaining"]}
+    client = TagApiClient(http)
+    result = client.remove(
+        resource="organization", resource_id=9, tags=["gone"]
+    )
+    http.delete.assert_called_with(
+        "/api/v2/organizations/9/tags",
+        json={"tags": ["gone"]},
+    )
+    assert result == ["remaining"]
+
+
+def test_remove_handles_none_response(http):
+    http.delete.return_value = None
+    client = TagApiClient(http)
+    assert client.remove(resource="ticket", resource_id=1, tags=["x"]) == []
+
+
+def test_add_missing_tags_key_returns_empty(http):
+    http.put.return_value = {}
+    client = TagApiClient(http)
+    assert client.add(resource="ticket", resource_id=1, tags=["x"]) == []
+
+
+def test_set_missing_tags_key_returns_empty(http):
+    http.post.return_value = {}
+    client = TagApiClient(http)
+    assert client.set(resource="ticket", resource_id=1, tags=["x"]) == []
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+def test_list_for_propagates_error(error_cls, http):
+    http.get.side_effect = error_cls("boom")
+    client = TagApiClient(http)
+    with pytest.raises(error_cls):
+        client.list_for(resource="ticket", resource_id=1)

--- a/tests/unit/ticketing/test_tags_service.py
+++ b/tests/unit/ticketing/test_tags_service.py
@@ -1,0 +1,70 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.services.ticketing.tags_service import TagsService
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return TagsService(client), client
+
+
+class TestDelegation:
+    def test_list_account_delegates(self):
+        service, client = _make_service()
+        client.list_account.return_value = sentinel.iter
+        assert service.list_account() is sentinel.iter
+        client.list_account.assert_called_once_with()
+
+    def test_list_for_delegates(self):
+        service, client = _make_service()
+        client.list_for.return_value = ["a", "b"]
+        result = service.list_for("ticket", 42)
+        client.list_for.assert_called_once_with(
+            resource="ticket", resource_id=42
+        )
+        assert result == ["a", "b"]
+
+    def test_add_delegates(self):
+        service, client = _make_service()
+        client.add.return_value = ["a", "b", "c"]
+        result = service.add("user", 7, ["c"])
+        client.add.assert_called_once_with(
+            resource="user", resource_id=7, tags=["c"]
+        )
+        assert result == ["a", "b", "c"]
+
+    def test_set_delegates(self):
+        service, client = _make_service()
+        client.set.return_value = ["x"]
+        result = service.set("organization", 9, ["x"])
+        client.set.assert_called_once_with(
+            resource="organization", resource_id=9, tags=["x"]
+        )
+        assert result == ["x"]
+
+    def test_remove_delegates(self):
+        service, client = _make_service()
+        client.remove.return_value = []
+        result = service.remove("ticket", 1, ["gone"])
+        client.remove.assert_called_once_with(
+            resource="ticket", resource_id=1, tags=["gone"]
+        )
+        assert result == []
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_for_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.list_for.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list_for("ticket", 1)
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_add_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.add.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.add("ticket", 1, ["x"])


### PR DESCRIPTION
## Summary
- Adds `TagApiClient` and `TagsService` unifying the Zendesk account-level tag listing (`/api/v2/tags`) with per-resource tag operations (add/set/remove) across tickets, users, and organizations.
- Dispatches by resource name (`ticket` | `user` | `organization`) to the correct endpoint; invalid resource raises `ValueError`.
- Wires `self.tags` onto the `Ticketing` facade.

## Test plan
- [x] Unit: `tests/unit/ticketing/test_tag_client.py` (paths, payloads, iterable-to-list, None response handling, error propagation)
- [x] Unit: `tests/unit/ticketing/test_tags_service.py` (delegation + error propagation)
- [x] Coverage: 100% on `tag_api_client.py` and `tags_service.py`
- [x] Full unit suite passes (600 tests)
- [ ] Live-tenant integration: `tests/integration/ticketing/test_tags.py` (list account, list_for ticket, add/set/remove lifecycle, invalid resource)

Part of #79 (Batch 2 — unified tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)