### PR TITLE
feat(ticketing): add ticket comments list/count/redact/make_private

### DIFF
--- a/libzapi/application/services/ticketing/__init__.py
+++ b/libzapi/application/services/ticketing/__init__.py
@@ -19,6 +19,7 @@ from libzapi.application.services.ticketing.support_addresses_service import Sup
 from libzapi.application.services.ticketing.suspended_tickets_service import SuspendedTicketsService
 from libzapi.application.services.ticketing.tickets_service import TickestService
 from libzapi.application.services.ticketing.ticket_audits_service import TicketAuditsService
+from libzapi.application.services.ticketing.ticket_comments_service import TicketCommentsService
 from libzapi.application.services.ticketing.ticket_fields_service import TicketFieldsService
 from libzapi.application.services.ticketing.ticket_forms_service import TicketFormsService
 from libzapi.application.services.ticketing.ticket_metrics_service import TicketMetricsService
@@ -64,6 +65,7 @@ class Ticketing:
         self.suspended_tickets = SuspendedTicketsService(api.SuspendedTicketApiClient(http))
         self.tickets = TickestService(api.TicketApiClient(http))
         self.ticket_audits = TicketAuditsService(api.TicketAuditApiClient(http))
+        self.ticket_comments = TicketCommentsService(api.TicketCommentApiClient(http))
         self.ticket_fields = TicketFieldsService(api.TicketFieldApiClient(http))
         self.ticket_forms = TicketFormsService(api.TicketFormApiClient(http))
         self.ticket_metrics = TicketMetricsService(api.TicketMetricApiClient(http))

--- a/libzapi/application/services/ticketing/ticket_comments_service.py
+++ b/libzapi/application/services/ticketing/ticket_comments_service.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+from libzapi.domain.models.ticketing.comment import Comment
+from libzapi.infrastructure.api_clients.ticketing.ticket_comment_api_client import (
+    TicketCommentApiClient,
+)
+
+
+class TicketCommentsService:
+    """High-level service for Zendesk ticket comments."""
+
+    def __init__(self, client: TicketCommentApiClient) -> None:
+        self._client = client
+
+    def list_for_ticket(
+        self,
+        ticket_id: int,
+        *,
+        include_inline_images: bool | None = None,
+        sort_order: str | None = None,
+    ) -> Iterator[Comment]:
+        return self._client.list(
+            ticket_id=ticket_id,
+            include_inline_images=include_inline_images,
+            sort_order=sort_order,
+        )
+
+    def count(self, ticket_id: int) -> int:
+        return self._client.count(ticket_id=ticket_id)
+
+    def redact(self, ticket_id: int, comment_id: int, text: str) -> Comment:
+        return self._client.redact(
+            ticket_id=ticket_id, comment_id=comment_id, text=text
+        )
+
+    def make_private(self, ticket_id: int, comment_id: int) -> None:
+        self._client.make_private(ticket_id=ticket_id, comment_id=comment_id)
+
+    def redact_attachment(
+        self, ticket_id: int, comment_id: int, attachment_id: int
+    ) -> Comment:
+        return self._client.redact_attachment(
+            ticket_id=ticket_id,
+            comment_id=comment_id,
+            attachment_id=attachment_id,
+        )
+
+    def redact_chat_comment(
+        self,
+        ticket_id: int,
+        comment_id: int,
+        chat_id: str,
+        message_ids: Iterable[str],
+        external_attachment_urls: Iterable[str] | None = None,
+    ) -> Comment:
+        return self._client.redact_chat_comment(
+            ticket_id=ticket_id,
+            comment_id=comment_id,
+            chat_id=chat_id,
+            message_ids=message_ids,
+            external_attachment_urls=external_attachment_urls,
+        )

--- a/libzapi/domain/models/ticketing/comment.py
+++ b/libzapi/domain/models/ticketing/comment.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional
+
+from libzapi.domain.models.ticketing.attachment import Attachment
+from libzapi.domain.shared_objects.logical_key import LogicalKey
+from libzapi.domain.shared_objects.via import Via
+
+
+@dataclass(frozen=True, slots=True)
+class Comment:
+    id: int
+    type: str
+    author_id: int
+    body: str
+    html_body: str
+    plain_body: str
+    public: bool
+    created_at: datetime
+    via: Optional[Via] = None
+    metadata: Optional[dict] = None
+    audit_id: Optional[int] = None
+    attachments: List[Attachment] = field(default_factory=list)
+
+    @property
+    def logical_key(self) -> LogicalKey:
+        return LogicalKey("ticket_comment", f"comment_id_{self.id}")

--- a/libzapi/infrastructure/api_clients/ticketing/__init__.py
+++ b/libzapi/infrastructure/api_clients/ticketing/__init__.py
@@ -18,6 +18,7 @@ from libzapi.infrastructure.api_clients.ticketing.suspended_ticket_api_client im
 from libzapi.infrastructure.api_clients.ticketing.support_address_api_client import SupportAddressApiClient
 from libzapi.infrastructure.api_clients.ticketing.ticket_api_client import TicketApiClient
 from libzapi.infrastructure.api_clients.ticketing.ticket_audit_api_client import TicketAuditApiClient
+from libzapi.infrastructure.api_clients.ticketing.ticket_comment_api_client import TicketCommentApiClient
 from libzapi.infrastructure.api_clients.ticketing.ticket_field_api_client import TicketFieldApiClient
 from libzapi.infrastructure.api_clients.ticketing.ticket_form_api_client import TicketFormApiClient
 from libzapi.infrastructure.api_clients.ticketing.ticket_metric_api_client import TicketMetricApiClient
@@ -50,6 +51,7 @@ __all__ = [
     "SuspendedTicketApiClient",
     "TicketApiClient",
     "TicketAuditApiClient",
+    "TicketCommentApiClient",
     "TicketFieldApiClient",
     "TicketFormApiClient",
     "TicketMetricApiClient",

--- a/libzapi/infrastructure/api_clients/ticketing/ticket_comment_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/ticket_comment_api_client.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+from libzapi.domain.models.ticketing.comment import Comment
+from libzapi.infrastructure.http.client import HttpClient
+from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.serialization.parse import to_domain
+
+
+class TicketCommentApiClient:
+    """HTTP adapter for Zendesk Ticket Comments."""
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def list(
+        self,
+        ticket_id: int,
+        *,
+        include_inline_images: bool | None = None,
+        sort_order: str | None = None,
+    ) -> Iterator[Comment]:
+        path = f"/api/v2/tickets/{int(ticket_id)}/comments"
+        params: list[str] = []
+        if include_inline_images is not None:
+            params.append(
+                "include_inline_images=" + ("true" if include_inline_images else "false")
+            )
+        if sort_order is not None:
+            params.append(f"sort_order={sort_order}")
+        if params:
+            path = f"{path}?{'&'.join(params)}"
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path=path,
+            base_url=self._http.base_url,
+            items_key="comments",
+        ):
+            yield to_domain(data=obj, cls=Comment)
+
+    def count(self, ticket_id: int) -> int:
+        data = self._http.get(f"/api/v2/tickets/{int(ticket_id)}/comments/count")
+        return int(data["count"]["value"])
+
+    def redact(
+        self,
+        ticket_id: int,
+        comment_id: int,
+        text: str,
+    ) -> Comment:
+        data = self._http.put(
+            f"/api/v2/tickets/{int(ticket_id)}/comments/{int(comment_id)}/redact",
+            {"text": text},
+        )
+        return to_domain(data=data["comment"], cls=Comment)
+
+    def make_private(self, ticket_id: int, comment_id: int) -> None:
+        self._http.put(
+            f"/api/v2/tickets/{int(ticket_id)}/comments/{int(comment_id)}/make_private",
+            {},
+        )
+
+    def redact_attachment(
+        self,
+        ticket_id: int,
+        comment_id: int,
+        attachment_id: int,
+    ) -> Comment:
+        data = self._http.put(
+            f"/api/v2/tickets/{int(ticket_id)}/comments/{int(comment_id)}/attachments/{int(attachment_id)}/redact",
+            {},
+        )
+        return to_domain(data=data["comment"], cls=Comment)
+
+    def redact_chat_comment(
+        self,
+        ticket_id: int,
+        comment_id: int,
+        chat_id: str,
+        message_ids: Iterable[str],
+        external_attachment_urls: Iterable[str] | None = None,
+    ) -> Comment:
+        payload: dict = {
+            "chat_id": chat_id,
+            "message_ids": list(message_ids),
+        }
+        if external_attachment_urls is not None:
+            payload["external_attachment_urls"] = list(external_attachment_urls)
+        data = self._http.put(
+            f"/api/v2/tickets/{int(ticket_id)}/comments/{int(comment_id)}/redact_chat_comment",
+            payload,
+        )
+        return to_domain(data=data["comment"], cls=Comment)

--- a/tests/integration/ticketing/test_ticket_comments.py
+++ b/tests/integration/ticketing/test_ticket_comments.py
@@ -1,0 +1,42 @@
+import itertools
+
+import pytest
+
+from libzapi import Ticketing
+
+
+def _first_ticket_id(ticketing: Ticketing) -> int:
+    for ticket in itertools.islice(ticketing.tickets.list(), 50):
+        return ticket.id
+    pytest.skip("No tickets available for comment tests.")
+
+
+def test_list_for_ticket(ticketing: Ticketing):
+    ticket_id = _first_ticket_id(ticketing)
+    comments = list(
+        itertools.islice(ticketing.ticket_comments.list_for_ticket(ticket_id), 10)
+    )
+    assert isinstance(comments, list)
+    for comment in comments:
+        assert comment.id > 0
+        assert comment.type == "Comment" or comment.type == "VoiceComment"
+
+
+def test_list_for_ticket_with_sort_desc(ticketing: Ticketing):
+    ticket_id = _first_ticket_id(ticketing)
+    comments = list(
+        itertools.islice(
+            ticketing.ticket_comments.list_for_ticket(
+                ticket_id, sort_order="desc"
+            ),
+            5,
+        )
+    )
+    assert isinstance(comments, list)
+
+
+def test_count_for_ticket(ticketing: Ticketing):
+    ticket_id = _first_ticket_id(ticketing)
+    count = ticketing.ticket_comments.count(ticket_id)
+    assert isinstance(count, int)
+    assert count >= 0

--- a/tests/unit/ticketing/test_comment.py
+++ b/tests/unit/ticketing/test_comment.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+
+from libzapi.domain.models.ticketing.comment import Comment
+
+
+def test_comment_logical_key():
+    c = Comment(
+        id=42,
+        type="Comment",
+        author_id=1,
+        body="hello",
+        html_body="<p>hello</p>",
+        plain_body="hello",
+        public=True,
+        created_at=datetime(2026, 1, 1),
+    )
+    assert c.logical_key.as_str() == "ticket_comment:comment_id_42"
+
+
+def test_comment_defaults_are_empty():
+    c = Comment(
+        id=1,
+        type="Comment",
+        author_id=1,
+        body="x",
+        html_body="x",
+        plain_body="x",
+        public=False,
+        created_at=datetime(2026, 1, 1),
+    )
+    assert c.attachments == []
+    assert c.via is None
+    assert c.metadata is None
+    assert c.audit_id is None

--- a/tests/unit/ticketing/test_ticket_comment_client.py
+++ b/tests/unit/ticketing/test_ticket_comment_client.py
@@ -1,0 +1,202 @@
+import pytest
+
+from libzapi.domain.errors import NotFound, Unauthorized
+from libzapi.infrastructure.api_clients.ticketing import TicketCommentApiClient
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.ticket_comment_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+@pytest.fixture
+def yield_items(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.ticket_comment_api_client.yield_items"
+    )
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+def test_list_hits_expected_path(http, yield_items, domain):
+    yield_items.return_value = iter([{"id": 1}])
+    client = TicketCommentApiClient(http)
+    list(client.list(42))
+    yield_items.assert_called_once_with(
+        get_json=http.get,
+        first_path="/api/v2/tickets/42/comments",
+        base_url=http.base_url,
+        items_key="comments",
+    )
+
+
+def test_list_with_include_inline_images_true(http, yield_items, domain):
+    yield_items.return_value = iter([])
+    client = TicketCommentApiClient(http)
+    list(client.list(42, include_inline_images=True))
+    assert (
+        yield_items.call_args.kwargs["first_path"]
+        == "/api/v2/tickets/42/comments?include_inline_images=true"
+    )
+
+
+def test_list_with_include_inline_images_false(http, yield_items, domain):
+    yield_items.return_value = iter([])
+    client = TicketCommentApiClient(http)
+    list(client.list(42, include_inline_images=False))
+    assert (
+        yield_items.call_args.kwargs["first_path"]
+        == "/api/v2/tickets/42/comments?include_inline_images=false"
+    )
+
+
+def test_list_with_sort_order(http, yield_items, domain):
+    yield_items.return_value = iter([])
+    client = TicketCommentApiClient(http)
+    list(client.list(42, sort_order="desc"))
+    assert (
+        yield_items.call_args.kwargs["first_path"]
+        == "/api/v2/tickets/42/comments?sort_order=desc"
+    )
+
+
+def test_list_combines_params(http, yield_items, domain):
+    yield_items.return_value = iter([])
+    client = TicketCommentApiClient(http)
+    list(client.list(42, include_inline_images=True, sort_order="desc"))
+    assert (
+        yield_items.call_args.kwargs["first_path"]
+        == "/api/v2/tickets/42/comments?include_inline_images=true&sort_order=desc"
+    )
+
+
+def test_list_yields_parsed_items(http, yield_items, domain):
+    yield_items.return_value = iter([{"id": 1}, {"id": 2}])
+    client = TicketCommentApiClient(http)
+    items = list(client.list(42))
+    assert len(items) == 2
+    assert items[0]["_cls"] == "Comment"
+
+
+# ---------------------------------------------------------------------------
+# count
+# ---------------------------------------------------------------------------
+
+
+def test_count_returns_value(http):
+    http.get.return_value = {"count": {"value": 17, "refreshed_at": "now"}}
+    client = TicketCommentApiClient(http)
+    assert client.count(42) == 17
+    http.get.assert_called_with("/api/v2/tickets/42/comments/count")
+
+
+# ---------------------------------------------------------------------------
+# redact
+# ---------------------------------------------------------------------------
+
+
+def test_redact_puts_payload(http, domain):
+    http.put.return_value = {"comment": {"id": 9}}
+    client = TicketCommentApiClient(http)
+    result = client.redact(ticket_id=42, comment_id=9, text="secret")
+    http.put.assert_called_with(
+        "/api/v2/tickets/42/comments/9/redact",
+        {"text": "secret"},
+    )
+    assert result["_cls"] == "Comment"
+
+
+# ---------------------------------------------------------------------------
+# make_private
+# ---------------------------------------------------------------------------
+
+
+def test_make_private_puts_empty_body(http):
+    client = TicketCommentApiClient(http)
+    client.make_private(ticket_id=42, comment_id=9)
+    http.put.assert_called_with(
+        "/api/v2/tickets/42/comments/9/make_private", {}
+    )
+
+
+# ---------------------------------------------------------------------------
+# redact_attachment
+# ---------------------------------------------------------------------------
+
+
+def test_redact_attachment_puts_empty_body(http, domain):
+    http.put.return_value = {"comment": {"id": 9}}
+    client = TicketCommentApiClient(http)
+    result = client.redact_attachment(
+        ticket_id=42, comment_id=9, attachment_id=3
+    )
+    http.put.assert_called_with(
+        "/api/v2/tickets/42/comments/9/attachments/3/redact", {}
+    )
+    assert result["_cls"] == "Comment"
+
+
+# ---------------------------------------------------------------------------
+# redact_chat_comment
+# ---------------------------------------------------------------------------
+
+
+def test_redact_chat_comment_puts_payload(http, domain):
+    http.put.return_value = {"comment": {"id": 9}}
+    client = TicketCommentApiClient(http)
+    client.redact_chat_comment(
+        ticket_id=42,
+        comment_id=9,
+        chat_id="chat-1",
+        message_ids=iter(["m1", "m2"]),
+    )
+    http.put.assert_called_with(
+        "/api/v2/tickets/42/comments/9/redact_chat_comment",
+        {"chat_id": "chat-1", "message_ids": ["m1", "m2"]},
+    )
+
+
+def test_redact_chat_comment_includes_external_urls(http, domain):
+    http.put.return_value = {"comment": {"id": 9}}
+    client = TicketCommentApiClient(http)
+    client.redact_chat_comment(
+        ticket_id=42,
+        comment_id=9,
+        chat_id="chat-1",
+        message_ids=["m1"],
+        external_attachment_urls=["https://x/y.png"],
+    )
+    http.put.assert_called_with(
+        "/api/v2/tickets/42/comments/9/redact_chat_comment",
+        {
+            "chat_id": "chat-1",
+            "message_ids": ["m1"],
+            "external_attachment_urls": ["https://x/y.png"],
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+def test_count_propagates_error(error_cls, http):
+    http.get.side_effect = error_cls("boom")
+    client = TicketCommentApiClient(http)
+    with pytest.raises(error_cls):
+        client.count(1)

--- a/tests/unit/ticketing/test_ticket_comments_service.py
+++ b/tests/unit/ticketing/test_ticket_comments_service.py
@@ -1,0 +1,103 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.services.ticketing.ticket_comments_service import (
+    TicketCommentsService,
+)
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return TicketCommentsService(client), client
+
+
+class TestDelegation:
+    def test_list_for_ticket_delegates(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.iter
+        assert service.list_for_ticket(42) is sentinel.iter
+        client.list.assert_called_once_with(
+            ticket_id=42, include_inline_images=None, sort_order=None
+        )
+
+    def test_list_for_ticket_passes_kwargs(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.iter
+        service.list_for_ticket(
+            42, include_inline_images=True, sort_order="desc"
+        )
+        client.list.assert_called_once_with(
+            ticket_id=42, include_inline_images=True, sort_order="desc"
+        )
+
+    def test_count_delegates(self):
+        service, client = _make_service()
+        client.count.return_value = 5
+        assert service.count(42) == 5
+        client.count.assert_called_once_with(ticket_id=42)
+
+    def test_redact_delegates(self):
+        service, client = _make_service()
+        client.redact.return_value = sentinel.comment
+        assert service.redact(42, 9, "secret") is sentinel.comment
+        client.redact.assert_called_once_with(
+            ticket_id=42, comment_id=9, text="secret"
+        )
+
+    def test_make_private_delegates(self):
+        service, client = _make_service()
+        service.make_private(42, 9)
+        client.make_private.assert_called_once_with(ticket_id=42, comment_id=9)
+
+    def test_redact_attachment_delegates(self):
+        service, client = _make_service()
+        client.redact_attachment.return_value = sentinel.comment
+        assert (
+            service.redact_attachment(42, 9, 3) is sentinel.comment
+        )
+        client.redact_attachment.assert_called_once_with(
+            ticket_id=42, comment_id=9, attachment_id=3
+        )
+
+    def test_redact_chat_comment_delegates(self):
+        service, client = _make_service()
+        client.redact_chat_comment.return_value = sentinel.comment
+        service.redact_chat_comment(
+            ticket_id=42,
+            comment_id=9,
+            chat_id="c",
+            message_ids=["m1"],
+        )
+        client.redact_chat_comment.assert_called_once_with(
+            ticket_id=42,
+            comment_id=9,
+            chat_id="c",
+            message_ids=["m1"],
+            external_attachment_urls=None,
+        )
+
+    def test_redact_chat_comment_passes_external_urls(self):
+        service, client = _make_service()
+        service.redact_chat_comment(
+            ticket_id=42,
+            comment_id=9,
+            chat_id="c",
+            message_ids=["m1"],
+            external_attachment_urls=["https://x/y.png"],
+        )
+        assert (
+            client.redact_chat_comment.call_args.kwargs[
+                "external_attachment_urls"
+            ]
+            == ["https://x/y.png"]
+        )
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_count_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.count.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.count(1)


### PR DESCRIPTION
## Summary
- Adds `TicketCommentApiClient` and `TicketCommentsService` exposing the available Zendesk ticket-comment operations (comments themselves are authored via ticket updates — not via a direct POST — so this PR covers list, count, redact, make_private, attachment and chat redact variants).
- Adds a `Comment` domain model with a `logical_key` of `ticket_comment:comment_id_<id>`.
- Wires `self.ticket_comments` onto the `Ticketing` facade.

## Test plan
- [x] Unit: `tests/unit/ticketing/test_ticket_comment_client.py` (path, query params, payload, parse)
- [x] Unit: `tests/unit/ticketing/test_ticket_comments_service.py` (delegation + error propagation)
- [x] Unit: `tests/unit/ticketing/test_comment.py` (logical_key + defaults)
- [x] Coverage: 100% on all new modules
- [x] Full unit suite passes (603 tests)
- [ ] Live-tenant integration: `tests/integration/ticketing/test_ticket_comments.py` (list, list with sort_order, count)

Part of #79 (Batch 2 — ticket comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)