### PR TITLE
feat(ticketing): add user identities CRUD + verify + make_primary

### DIFF
--- a/libzapi/application/commands/ticketing/user_identity_cmds.py
+++ b/libzapi/application/commands/ticketing/user_identity_cmds.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TypeAlias
+
+
+@dataclass(frozen=True, slots=True)
+class CreateUserIdentityCmd:
+    type: str
+    value: str
+    verified: bool | None = None
+    primary: bool | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateUserIdentityCmd:
+    value: str | None = None
+    verified: bool | None = None
+
+
+UserIdentityCmd: TypeAlias = CreateUserIdentityCmd | UpdateUserIdentityCmd

--- a/libzapi/application/services/ticketing/__init__.py
+++ b/libzapi/application/services/ticketing/__init__.py
@@ -26,6 +26,7 @@ from libzapi.application.services.ticketing.ticket_trigger_categories_service im
 from libzapi.application.services.ticketing.ticket_trigger_service import TicketTriggerService
 from libzapi.application.services.ticketing.users_service import UsersService
 from libzapi.application.services.ticketing.user_fields_service import UserFieldsService
+from libzapi.application.services.ticketing.user_identities_service import UserIdentitiesService
 from libzapi.application.services.ticketing.views_service import ViewsService
 from libzapi.application.services.ticketing.workspace_service import WorkspaceService
 from libzapi.infrastructure.http.auth import oauth_headers, api_token_headers
@@ -72,5 +73,6 @@ class Ticketing:
         self.ticket_trigger_categories = TicketTriggerCategoriesService(api.TicketTriggerCategoryApiClient(http))
         self.users = UsersService(api.UserApiClient(http))
         self.user_fields = UserFieldsService(api.UserFieldApiClient(http))
+        self.user_identities = UserIdentitiesService(api.UserIdentityApiClient(http))
         self.views = ViewsService(api.ViewApiClient(http))
         self.workspaces = WorkspaceService(api.WorkspaceApiClient(http))

--- a/libzapi/application/services/ticketing/user_identities_service.py
+++ b/libzapi/application/services/ticketing/user_identities_service.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from libzapi.application.commands.ticketing.user_identity_cmds import (
+    CreateUserIdentityCmd,
+    UpdateUserIdentityCmd,
+)
+from libzapi.domain.models.ticketing.user_identity import UserIdentity
+from libzapi.infrastructure.api_clients.ticketing.user_identity_api_client import (
+    UserIdentityApiClient,
+)
+
+
+class UserIdentitiesService:
+    """High-level service for Zendesk user identities."""
+
+    def __init__(self, client: UserIdentityApiClient) -> None:
+        self._client = client
+
+    def list_for_user(self, user_id: int) -> Iterable[UserIdentity]:
+        return self._client.list(user_id)
+
+    def get_by_id(self, user_id: int, identity_id: int) -> UserIdentity:
+        return self._client.get(user_id=user_id, identity_id=identity_id)
+
+    def create(
+        self,
+        user_id: int,
+        type: str,
+        value: str,
+        verified: bool | None = None,
+        primary: bool | None = None,
+    ) -> UserIdentity:
+        return self._client.create(
+            user_id=user_id,
+            entity=CreateUserIdentityCmd(
+                type=type, value=value, verified=verified, primary=primary
+            ),
+        )
+
+    def update(
+        self,
+        user_id: int,
+        identity_id: int,
+        **fields,
+    ) -> UserIdentity:
+        return self._client.update(
+            user_id=user_id,
+            identity_id=identity_id,
+            entity=UpdateUserIdentityCmd(**fields),
+        )
+
+    def delete(self, user_id: int, identity_id: int) -> None:
+        self._client.delete(user_id=user_id, identity_id=identity_id)
+
+    def make_primary(
+        self, user_id: int, identity_id: int
+    ) -> list[UserIdentity]:
+        return self._client.make_primary(
+            user_id=user_id, identity_id=identity_id
+        )
+
+    def verify(self, user_id: int, identity_id: int) -> UserIdentity:
+        return self._client.verify(user_id=user_id, identity_id=identity_id)
+
+    def request_verification(
+        self, user_id: int, identity_id: int
+    ) -> None:
+        self._client.request_verification(
+            user_id=user_id, identity_id=identity_id
+        )

--- a/libzapi/domain/models/ticketing/user_identity.py
+++ b/libzapi/domain/models/ticketing/user_identity.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from libzapi.domain.shared_objects.logical_key import LogicalKey
+
+
+@dataclass(frozen=True, slots=True)
+class UserIdentity:
+    id: int
+    user_id: int
+    type: str
+    value: str
+    verified: bool
+    primary: bool
+    created_at: datetime
+    updated_at: datetime
+    url: Optional[str] = None
+    undeliverable_count: Optional[int] = None
+    deliverable_state: Optional[str] = None
+
+    @property
+    def logical_key(self) -> LogicalKey:
+        return LogicalKey(
+            "user_identity", f"u{self.user_id}_id{self.id}"
+        )

--- a/libzapi/infrastructure/api_clients/ticketing/__init__.py
+++ b/libzapi/infrastructure/api_clients/ticketing/__init__.py
@@ -28,6 +28,7 @@ from libzapi.infrastructure.api_clients.ticketing.ticket_trigger_category_api_cl
 )
 from libzapi.infrastructure.api_clients.ticketing.user_api_client import UserApiClient
 from libzapi.infrastructure.api_clients.ticketing.user_field_api_client import UserFieldApiClient
+from libzapi.infrastructure.api_clients.ticketing.user_identity_api_client import UserIdentityApiClient
 from libzapi.infrastructure.api_clients.ticketing.view_api_client import ViewApiClient
 from libzapi.infrastructure.api_clients.ticketing.workspace_api_client import WorkspaceApiClient
 
@@ -58,6 +59,7 @@ __all__ = [
     "TicketTriggerCategoryApiClient",
     "UserApiClient",
     "UserFieldApiClient",
+    "UserIdentityApiClient",
     "ViewApiClient",
     "WorkspaceApiClient",
 ]

--- a/libzapi/infrastructure/api_clients/ticketing/user_identity_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/user_identity_api_client.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+from libzapi.application.commands.ticketing.user_identity_cmds import (
+    CreateUserIdentityCmd,
+    UpdateUserIdentityCmd,
+)
+from libzapi.domain.models.ticketing.user_identity import UserIdentity
+from libzapi.infrastructure.http.client import HttpClient
+from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.mappers.ticketing.user_identity_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
+from libzapi.infrastructure.serialization.parse import to_domain
+
+
+class UserIdentityApiClient:
+    """HTTP adapter for Zendesk User Identities."""
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def list(self, user_id: int) -> Iterator[UserIdentity]:
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path=f"/api/v2/users/{int(user_id)}/identities",
+            base_url=self._http.base_url,
+            items_key="identities",
+        ):
+            yield to_domain(data=obj, cls=UserIdentity)
+
+    def get(self, user_id: int, identity_id: int) -> UserIdentity:
+        data = self._http.get(
+            f"/api/v2/users/{int(user_id)}/identities/{int(identity_id)}"
+        )
+        return to_domain(data=data["identity"], cls=UserIdentity)
+
+    def create(
+        self, user_id: int, entity: CreateUserIdentityCmd
+    ) -> UserIdentity:
+        payload = to_payload_create(entity)
+        data = self._http.post(
+            f"/api/v2/users/{int(user_id)}/identities", payload
+        )
+        return to_domain(data=data["identity"], cls=UserIdentity)
+
+    def update(
+        self,
+        user_id: int,
+        identity_id: int,
+        entity: UpdateUserIdentityCmd,
+    ) -> UserIdentity:
+        payload = to_payload_update(entity)
+        data = self._http.put(
+            f"/api/v2/users/{int(user_id)}/identities/{int(identity_id)}",
+            payload,
+        )
+        return to_domain(data=data["identity"], cls=UserIdentity)
+
+    def delete(self, user_id: int, identity_id: int) -> None:
+        self._http.delete(
+            f"/api/v2/users/{int(user_id)}/identities/{int(identity_id)}"
+        )
+
+    def make_primary(
+        self, user_id: int, identity_id: int
+    ) -> list[UserIdentity]:
+        data = self._http.put(
+            f"/api/v2/users/{int(user_id)}/identities/{int(identity_id)}/make_primary",
+            {},
+        )
+        return [
+            to_domain(data=obj, cls=UserIdentity)
+            for obj in data.get("identities", []) or []
+        ]
+
+    def verify(self, user_id: int, identity_id: int) -> UserIdentity:
+        data = self._http.put(
+            f"/api/v2/users/{int(user_id)}/identities/{int(identity_id)}/verify",
+            {},
+        )
+        return to_domain(data=data["identity"], cls=UserIdentity)
+
+    def request_verification(
+        self, user_id: int, identity_id: int
+    ) -> None:
+        self._http.put(
+            f"/api/v2/users/{int(user_id)}/identities/{int(identity_id)}/request_verification",
+            {},
+        )

--- a/libzapi/infrastructure/mappers/ticketing/user_identity_mapper.py
+++ b/libzapi/infrastructure/mappers/ticketing/user_identity_mapper.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from libzapi.application.commands.ticketing.user_identity_cmds import (
+    CreateUserIdentityCmd,
+    UpdateUserIdentityCmd,
+)
+
+
+def to_payload_create(cmd: CreateUserIdentityCmd) -> dict:
+    body: dict = {"type": cmd.type, "value": cmd.value}
+    if cmd.verified is not None:
+        body["verified"] = cmd.verified
+    if cmd.primary is not None:
+        body["primary"] = cmd.primary
+    return {"identity": body}
+
+
+def to_payload_update(cmd: UpdateUserIdentityCmd) -> dict:
+    body: dict = {}
+    if cmd.value is not None:
+        body["value"] = cmd.value
+    if cmd.verified is not None:
+        body["verified"] = cmd.verified
+    return {"identity": body}

--- a/tests/integration/ticketing/test_user_identities.py
+++ b/tests/integration/ticketing/test_user_identities.py
@@ -1,0 +1,88 @@
+import uuid
+
+from libzapi import Ticketing
+
+
+def _unique() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+def _fresh_end_user(ticketing: Ticketing):
+    return ticketing.users.create(
+        name=f"libzapi identity test {_unique()}",
+        email=f"libzapi_{_unique()}@example.test",
+        role="end-user",
+    )
+
+
+def test_list_for_user(ticketing: Ticketing):
+    user = _fresh_end_user(ticketing)
+    try:
+        identities = list(ticketing.user_identities.list_for_user(user.id))
+        assert isinstance(identities, list)
+        assert any(i.type == "email" for i in identities)
+    finally:
+        ticketing.users.delete(user.id)
+
+
+def test_create_get_delete_phone_identity(ticketing: Ticketing):
+    user = _fresh_end_user(ticketing)
+    try:
+        created = ticketing.user_identities.create(
+            user_id=user.id,
+            type="phone_number",
+            value=f"+1555{_unique()[:7]}",
+            verified=True,
+        )
+        assert created.id > 0
+        assert created.verified is True
+
+        fetched = ticketing.user_identities.get_by_id(user.id, created.id)
+        assert fetched.id == created.id
+
+        ticketing.user_identities.delete(user.id, created.id)
+    finally:
+        ticketing.users.delete(user.id)
+
+
+def test_update_identity(ticketing: Ticketing):
+    user = _fresh_end_user(ticketing)
+    try:
+        created = ticketing.user_identities.create(
+            user_id=user.id,
+            type="email",
+            value=f"extra_{_unique()}@example.test",
+            verified=True,
+        )
+        try:
+            new_value = f"renamed_{_unique()}@example.test"
+            updated = ticketing.user_identities.update(
+                user.id, created.id, value=new_value
+            )
+            assert updated.value == new_value
+        finally:
+            ticketing.user_identities.delete(user.id, created.id)
+    finally:
+        ticketing.users.delete(user.id)
+
+
+def test_make_primary_promotes_identity(ticketing: Ticketing):
+    user = _fresh_end_user(ticketing)
+    try:
+        created = ticketing.user_identities.create(
+            user_id=user.id,
+            type="email",
+            value=f"primary_{_unique()}@example.test",
+            verified=True,
+        )
+        try:
+            identities = ticketing.user_identities.make_primary(
+                user.id, created.id
+            )
+            assert any(i.id == created.id and i.primary for i in identities)
+        finally:
+            # promoted identity cannot be deleted if it's the sole primary.
+            # Restore original primary by deleting user (handled in outer finally).
+            pass
+    finally:
+        ticketing.users.delete(user.id)

--- a/tests/unit/ticketing/test_user_identities_service.py
+++ b/tests/unit/ticketing/test_user_identities_service.py
@@ -1,0 +1,113 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.commands.ticketing.user_identity_cmds import (
+    CreateUserIdentityCmd,
+    UpdateUserIdentityCmd,
+)
+from libzapi.application.services.ticketing.user_identities_service import (
+    UserIdentitiesService,
+)
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return UserIdentitiesService(client), client
+
+
+class TestDelegation:
+    def test_list_for_user_delegates(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.iter
+        assert service.list_for_user(42) is sentinel.iter
+        client.list.assert_called_once_with(42)
+
+    def test_get_by_id_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.identity
+        assert service.get_by_id(3, 9) is sentinel.identity
+        client.get.assert_called_once_with(user_id=3, identity_id=9)
+
+    def test_delete_delegates(self):
+        service, client = _make_service()
+        service.delete(3, 9)
+        client.delete.assert_called_once_with(user_id=3, identity_id=9)
+
+    def test_make_primary_delegates(self):
+        service, client = _make_service()
+        client.make_primary.return_value = sentinel.list_
+        assert service.make_primary(3, 9) is sentinel.list_
+        client.make_primary.assert_called_once_with(user_id=3, identity_id=9)
+
+    def test_verify_delegates(self):
+        service, client = _make_service()
+        client.verify.return_value = sentinel.identity
+        assert service.verify(3, 9) is sentinel.identity
+        client.verify.assert_called_once_with(user_id=3, identity_id=9)
+
+    def test_request_verification_delegates(self):
+        service, client = _make_service()
+        service.request_verification(3, 9)
+        client.request_verification.assert_called_once_with(
+            user_id=3, identity_id=9
+        )
+
+
+class TestCreate:
+    def test_builds_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.create.return_value = sentinel.identity
+        result = service.create(
+            user_id=3,
+            type="email",
+            value="x@y.com",
+            verified=True,
+            primary=False,
+        )
+        call = client.create.call_args
+        assert call.kwargs["user_id"] == 3
+        cmd = call.kwargs["entity"]
+        assert isinstance(cmd, CreateUserIdentityCmd)
+        assert cmd.type == "email"
+        assert cmd.value == "x@y.com"
+        assert cmd.verified is True
+        assert cmd.primary is False
+        assert result is sentinel.identity
+
+    def test_defaults_omitted_are_none(self):
+        service, client = _make_service()
+        service.create(user_id=3, type="email", value="x@y.com")
+        cmd = client.create.call_args.kwargs["entity"]
+        assert cmd.verified is None
+        assert cmd.primary is None
+
+
+class TestUpdate:
+    def test_builds_cmd_with_kwargs(self):
+        service, client = _make_service()
+        client.update.return_value = sentinel.identity
+        service.update(3, 9, value="new@y.com", verified=True)
+        call = client.update.call_args
+        assert call.kwargs["user_id"] == 3
+        assert call.kwargs["identity_id"] == 9
+        cmd = call.kwargs["entity"]
+        assert isinstance(cmd, UpdateUserIdentityCmd)
+        assert cmd.value == "new@y.com"
+        assert cmd.verified is True
+
+    def test_empty_kwargs_builds_empty_cmd(self):
+        service, client = _make_service()
+        service.update(3, 9)
+        cmd = client.update.call_args.kwargs["entity"]
+        assert cmd.value is None
+        assert cmd.verified is None
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_get_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.get.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.get_by_id(1, 2)

--- a/tests/unit/ticketing/test_user_identity.py
+++ b/tests/unit/ticketing/test_user_identity.py
@@ -1,0 +1,167 @@
+import pytest
+
+from libzapi.application.commands.ticketing.user_identity_cmds import (
+    CreateUserIdentityCmd,
+    UpdateUserIdentityCmd,
+)
+from libzapi.domain.errors import NotFound, Unauthorized
+from libzapi.infrastructure.api_clients.ticketing import UserIdentityApiClient
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.user_identity_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+def test_list_hits_expected_path(http, domain):
+    http.get.return_value = {
+        "identities": [{"id": 1}, {"id": 2}],
+        "meta": {"has_more": False},
+        "links": {"next": None},
+    }
+    client = UserIdentityApiClient(http)
+    items = list(client.list(42))
+    http.get.assert_called_with("/api/v2/users/42/identities")
+    assert len(items) == 2
+
+
+# ---------------------------------------------------------------------------
+# get / create / update / delete
+# ---------------------------------------------------------------------------
+
+
+def test_get_calls_endpoint(http, domain):
+    http.get.return_value = {"identity": {"id": 9}}
+    client = UserIdentityApiClient(http)
+    client.get(user_id=3, identity_id=9)
+    http.get.assert_called_with("/api/v2/users/3/identities/9")
+
+
+def test_create_posts_payload(http, domain):
+    http.post.return_value = {"identity": {"id": 1}}
+    client = UserIdentityApiClient(http)
+    client.create(
+        user_id=3,
+        entity=CreateUserIdentityCmd(
+            type="email", value="x@y.com", verified=True, primary=False
+        ),
+    )
+    http.post.assert_called_with(
+        "/api/v2/users/3/identities",
+        {
+            "identity": {
+                "type": "email",
+                "value": "x@y.com",
+                "verified": True,
+                "primary": False,
+            }
+        },
+    )
+
+
+def test_update_puts_payload(http, domain):
+    http.put.return_value = {"identity": {"id": 9}}
+    client = UserIdentityApiClient(http)
+    client.update(
+        user_id=3,
+        identity_id=9,
+        entity=UpdateUserIdentityCmd(value="new@y.com"),
+    )
+    http.put.assert_called_with(
+        "/api/v2/users/3/identities/9",
+        {"identity": {"value": "new@y.com"}},
+    )
+
+
+def test_delete_calls_endpoint(http):
+    client = UserIdentityApiClient(http)
+    client.delete(user_id=3, identity_id=9)
+    http.delete.assert_called_with("/api/v2/users/3/identities/9")
+
+
+# ---------------------------------------------------------------------------
+# make_primary / verify / request_verification
+# ---------------------------------------------------------------------------
+
+
+def test_make_primary_returns_list(http, domain):
+    http.put.return_value = {"identities": [{"id": 1}, {"id": 2}]}
+    client = UserIdentityApiClient(http)
+    result = client.make_primary(user_id=3, identity_id=9)
+    http.put.assert_called_with(
+        "/api/v2/users/3/identities/9/make_primary", {}
+    )
+    assert len(result) == 2
+
+
+def test_make_primary_handles_null(http, domain):
+    http.put.return_value = {"identities": None}
+    client = UserIdentityApiClient(http)
+    assert client.make_primary(user_id=3, identity_id=9) == []
+
+
+def test_verify_returns_identity(http, domain):
+    http.put.return_value = {"identity": {"id": 9, "verified": True}}
+    client = UserIdentityApiClient(http)
+    result = client.verify(user_id=3, identity_id=9)
+    http.put.assert_called_with("/api/v2/users/3/identities/9/verify", {})
+    assert result["_cls"] == "UserIdentity"
+
+
+def test_request_verification_puts_empty_body(http):
+    client = UserIdentityApiClient(http)
+    client.request_verification(user_id=3, identity_id=9)
+    http.put.assert_called_with(
+        "/api/v2/users/3/identities/9/request_verification", {}
+    )
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+def test_get_propagates_error(error_cls, http):
+    http.get.side_effect = error_cls("boom")
+    client = UserIdentityApiClient(http)
+    with pytest.raises(error_cls):
+        client.get(user_id=1, identity_id=2)
+
+
+# ---------------------------------------------------------------------------
+# Domain logical key
+# ---------------------------------------------------------------------------
+
+
+def test_user_identity_logical_key():
+    from datetime import datetime
+
+    from libzapi.domain.models.ticketing.user_identity import UserIdentity
+
+    identity = UserIdentity(
+        id=9,
+        user_id=42,
+        type="email",
+        value="x@y.com",
+        verified=True,
+        primary=False,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    assert identity.logical_key.as_str() == "user_identity:u42_id9"

--- a/tests/unit/ticketing/test_user_identity_mapper.py
+++ b/tests/unit/ticketing/test_user_identity_mapper.py
@@ -1,0 +1,62 @@
+from libzapi.application.commands.ticketing.user_identity_cmds import (
+    CreateUserIdentityCmd,
+    UpdateUserIdentityCmd,
+)
+from libzapi.infrastructure.mappers.ticketing.user_identity_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
+
+
+def test_create_minimal():
+    cmd = CreateUserIdentityCmd(type="email", value="x@y.com")
+    assert to_payload_create(cmd) == {
+        "identity": {"type": "email", "value": "x@y.com"}
+    }
+
+
+def test_create_with_verified_true():
+    cmd = CreateUserIdentityCmd(type="email", value="x@y.com", verified=True)
+    assert to_payload_create(cmd)["identity"]["verified"] is True
+
+
+def test_create_with_verified_false():
+    cmd = CreateUserIdentityCmd(type="email", value="x@y.com", verified=False)
+    assert to_payload_create(cmd)["identity"]["verified"] is False
+
+
+def test_create_with_primary_true():
+    cmd = CreateUserIdentityCmd(type="email", value="x@y.com", primary=True)
+    assert to_payload_create(cmd)["identity"]["primary"] is True
+
+
+def test_create_with_primary_false():
+    cmd = CreateUserIdentityCmd(type="email", value="x@y.com", primary=False)
+    assert to_payload_create(cmd)["identity"]["primary"] is False
+
+
+def test_update_empty():
+    cmd = UpdateUserIdentityCmd()
+    assert to_payload_update(cmd) == {"identity": {}}
+
+
+def test_update_value_only():
+    cmd = UpdateUserIdentityCmd(value="new@y.com")
+    assert to_payload_update(cmd) == {"identity": {"value": "new@y.com"}}
+
+
+def test_update_verified_only():
+    cmd = UpdateUserIdentityCmd(verified=True)
+    assert to_payload_update(cmd) == {"identity": {"verified": True}}
+
+
+def test_update_verified_false():
+    cmd = UpdateUserIdentityCmd(verified=False)
+    assert to_payload_update(cmd)["identity"]["verified"] is False
+
+
+def test_update_both():
+    cmd = UpdateUserIdentityCmd(value="new@y.com", verified=True)
+    assert to_payload_update(cmd) == {
+        "identity": {"value": "new@y.com", "verified": True}
+    }


### PR DESCRIPTION
## Summary
- Adds `UserIdentityApiClient` + `UserIdentitiesService` exposing the full Zendesk user-identity surface: `list`, `get`, `create`, `update`, `delete`, `make_primary`, `verify`, `request_verification`.
- Adds `UserIdentity` domain model (logical_key: `user_identity:u<user>_id<id>`), `CreateUserIdentityCmd` (type/value/verified?/primary?) and `UpdateUserIdentityCmd` (value?/verified?) with false-boolean preservation in the mapper.
- Wires `self.user_identities` onto the `Ticketing` facade.

## Test plan
- [x] Unit: `tests/unit/ticketing/test_user_identity.py` — paths, payloads, make_primary null handling, error propagation, logical_key
- [x] Unit: `tests/unit/ticketing/test_user_identity_mapper.py` — false-boolean preservation for `verified`/`primary`
- [x] Unit: `tests/unit/ticketing/test_user_identities_service.py` — delegation + kwargs-to-cmd
- [x] Coverage: 100% on all new modules (109 statements)
- [x] Full unit suite passes (611 tests)
- [ ] Live-tenant integration: `tests/integration/ticketing/test_user_identities.py` (list, create/get/delete phone identity, update, make_primary)

Part of #79 (Batch 2 — user identities).

🤖 Generated with [Claude Code](https://claude.com/claude-code)