### PR TITLE
feat(ticketing): add job statuses + wait_until_complete helper

### DIFF
--- a/libzapi/application/services/ticketing/__init__.py
+++ b/libzapi/application/services/ticketing/__init__.py
@@ -9,6 +9,7 @@ from libzapi.application.services.ticketing.groups_service import GroupsService
 from libzapi.application.services.ticketing.group_memberships_service import (
     GroupMembershipsService,
 )
+from libzapi.application.services.ticketing.job_statuses_service import JobStatusesService
 from libzapi.application.services.ticketing.macro_service import MacroService
 from libzapi.application.services.ticketing.organizations_service import OrganizationsService
 from libzapi.application.services.ticketing.requests_service import RequestsService
@@ -54,6 +55,7 @@ class Ticketing:
         self.email_notifications = EmailNotificationService(api.EmailNotificationApiClient(http))
         self.groups = GroupsService(api.GroupApiClient(http))
         self.group_memberships = GroupMembershipsService(api.GroupMembershipApiClient(http))
+        self.job_statuses = JobStatusesService(api.JobStatusApiClient(http))
         self.macros = MacroService(api.MacroApiClient(http))
         self.organizations = OrganizationsService(api.OrganizationApiClient(http))
         self.requests = RequestsService(api.RequestApiClient(http))

--- a/libzapi/application/services/ticketing/job_statuses_service.py
+++ b/libzapi/application/services/ticketing/job_statuses_service.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import time
+from typing import Callable, Iterable, Iterator
+
+from libzapi.domain.shared_objects.job_status import JobStatus
+from libzapi.infrastructure.api_clients.ticketing.job_status_api_client import (
+    JobStatusApiClient,
+)
+
+
+_TERMINAL_STATUSES = frozenset({"completed", "failed", "killed"})
+
+
+class JobStatusTimeout(Exception):
+    """Raised when a job status does not reach a terminal state in time."""
+
+
+class JobStatusesService:
+    """High-level service for Zendesk job statuses."""
+
+    def __init__(self, client: JobStatusApiClient) -> None:
+        self._client = client
+
+    def list_all(self) -> Iterator[JobStatus]:
+        return self._client.list()
+
+    def get_by_id(self, job_id: str) -> JobStatus:
+        return self._client.get(job_id=job_id)
+
+    def show_many(self, job_ids: Iterable[str]) -> list[JobStatus]:
+        return self._client.show_many(job_ids=job_ids)
+
+    def wait_until_complete(
+        self,
+        job_id: str,
+        interval: float = 1.0,
+        timeout: float = 60.0,
+        sleep: Callable[[float], None] = time.sleep,
+        now: Callable[[], float] = time.monotonic,
+    ) -> JobStatus:
+        """Poll a job status until it reaches a terminal state.
+
+        Raises JobStatusTimeout if the job does not finish within `timeout`
+        seconds. `sleep` and `now` are injectable for testing.
+        """
+        deadline = now() + timeout
+        while True:
+            status = self._client.get(job_id=job_id)
+            if status.status in _TERMINAL_STATUSES:
+                return status
+            if now() >= deadline:
+                raise JobStatusTimeout(
+                    f"job {job_id} did not complete within {timeout}s"
+                )
+            sleep(interval)

--- a/libzapi/infrastructure/api_clients/ticketing/__init__.py
+++ b/libzapi/infrastructure/api_clients/ticketing/__init__.py
@@ -8,6 +8,7 @@ from libzapi.infrastructure.api_clients.ticketing.group_api_client import GroupA
 from libzapi.infrastructure.api_clients.ticketing.group_membership_api_client import (
     GroupMembershipApiClient,
 )
+from libzapi.infrastructure.api_clients.ticketing.job_status_api_client import JobStatusApiClient
 from libzapi.infrastructure.api_clients.ticketing.macro_api_client import MacroApiClient
 from libzapi.infrastructure.api_clients.ticketing.organization_api_client import OrganizationApiClient
 from libzapi.infrastructure.api_clients.ticketing.request_api_client import RequestApiClient
@@ -40,6 +41,7 @@ __all__ = [
     "EmailNotificationApiClient",
     "GroupApiClient",
     "GroupMembershipApiClient",
+    "JobStatusApiClient",
     "MacroApiClient",
     "OrganizationApiClient",
     "RequestApiClient",

--- a/libzapi/infrastructure/api_clients/ticketing/job_status_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/job_status_api_client.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+from libzapi.domain.shared_objects.job_status import JobStatus
+from libzapi.infrastructure.http.client import HttpClient
+from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.serialization.parse import to_domain
+
+
+class JobStatusApiClient:
+    """HTTP adapter for Zendesk Job Statuses."""
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def list(self) -> Iterator[JobStatus]:
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path="/api/v2/job_statuses",
+            base_url=self._http.base_url,
+            items_key="job_statuses",
+        ):
+            yield to_domain(data=obj, cls=JobStatus)
+
+    def get(self, job_id: str) -> JobStatus:
+        data = self._http.get(f"/api/v2/job_statuses/{job_id}")
+        return to_domain(data=data["job_status"], cls=JobStatus)
+
+    def show_many(self, job_ids: Iterable[str]) -> list[JobStatus]:
+        ids_str = ",".join(str(i) for i in job_ids)
+        data = self._http.get(f"/api/v2/job_statuses/show_many?ids={ids_str}")
+        return [
+            to_domain(data=obj, cls=JobStatus)
+            for obj in data.get("job_statuses", []) or []
+        ]

--- a/tests/integration/ticketing/test_job_statuses.py
+++ b/tests/integration/ticketing/test_job_statuses.py
@@ -1,0 +1,34 @@
+import itertools
+
+import pytest
+
+from libzapi import Ticketing
+
+
+def test_list_all(ticketing: Ticketing):
+    items = list(itertools.islice(ticketing.job_statuses.list_all(), 20))
+    assert isinstance(items, list)
+
+
+def test_get_unknown_raises(ticketing: Ticketing):
+    from libzapi.domain.errors import NotFound
+
+    with pytest.raises(NotFound):
+        ticketing.job_statuses.get_by_id("this-job-does-not-exist-" + "0" * 20)
+
+
+def test_wait_until_complete_on_known_job(ticketing: Ticketing):
+    jobs = list(itertools.islice(ticketing.job_statuses.list_all(), 5))
+    if not jobs:
+        pytest.skip("No job statuses available on this tenant.")
+    finished = [
+        j for j in jobs if j.status in {"completed", "failed", "killed"}
+    ]
+    if not finished:
+        pytest.skip("No terminal job statuses available on this tenant.")
+    target = finished[0]
+    result = ticketing.job_statuses.wait_until_complete(
+        target.id, interval=0.5, timeout=5.0
+    )
+    assert result.id == target.id
+    assert result.status in {"completed", "failed", "killed"}

--- a/tests/unit/ticketing/test_job_status_client.py
+++ b/tests/unit/ticketing/test_job_status_client.py
@@ -1,0 +1,66 @@
+import pytest
+
+from libzapi.domain.errors import NotFound, Unauthorized
+from libzapi.infrastructure.api_clients.ticketing import JobStatusApiClient
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.job_status_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+def test_list_yields_job_statuses(http, domain):
+    http.get.return_value = {
+        "job_statuses": [{"id": "a"}, {"id": "b"}],
+        "meta": {"has_more": False},
+        "links": {"next": None},
+    }
+    client = JobStatusApiClient(http)
+    items = list(client.list())
+    http.get.assert_called_with("/api/v2/job_statuses")
+    assert len(items) == 2
+
+
+def test_get_calls_endpoint(http, domain):
+    http.get.return_value = {"job_status": {"id": "abc"}}
+    client = JobStatusApiClient(http)
+    client.get("abc")
+    http.get.assert_called_with("/api/v2/job_statuses/abc")
+
+
+def test_show_many_builds_path(http, domain):
+    http.get.return_value = {"job_statuses": [{"id": "a"}, {"id": "b"}]}
+    client = JobStatusApiClient(http)
+    result = client.show_many(["a", "b"])
+    http.get.assert_called_with("/api/v2/job_statuses/show_many?ids=a,b")
+    assert len(result) == 2
+
+
+def test_show_many_handles_missing_key(http, domain):
+    http.get.return_value = {}
+    client = JobStatusApiClient(http)
+    assert client.show_many(["a"]) == []
+
+
+def test_show_many_handles_null(http, domain):
+    http.get.return_value = {"job_statuses": None}
+    client = JobStatusApiClient(http)
+    assert client.show_many(["a"]) == []
+
+
+@pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+def test_get_propagates_error(error_cls, http):
+    http.get.side_effect = error_cls("boom")
+    client = JobStatusApiClient(http)
+    with pytest.raises(error_cls):
+        client.get("abc")

--- a/tests/unit/ticketing/test_job_statuses_service.py
+++ b/tests/unit/ticketing/test_job_statuses_service.py
@@ -1,0 +1,116 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.services.ticketing.job_statuses_service import (
+    JobStatusesService,
+    JobStatusTimeout,
+)
+from libzapi.domain.errors import NotFound, Unauthorized
+from libzapi.domain.shared_objects.job_status import JobStatus
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return JobStatusesService(client), client
+
+
+def _make_status(status: str) -> JobStatus:
+    return JobStatus(
+        id="abc",
+        job_type="",
+        url="",
+        total=0,
+        progress="",
+        status=status,
+        message="",
+    )
+
+
+class TestDelegation:
+    def test_list_all_delegates(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.iter
+        assert service.list_all() is sentinel.iter
+        client.list.assert_called_once_with()
+
+    def test_get_by_id_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.status
+        assert service.get_by_id("abc") is sentinel.status
+        client.get.assert_called_once_with(job_id="abc")
+
+    def test_show_many_delegates(self):
+        service, client = _make_service()
+        client.show_many.return_value = [sentinel.a]
+        assert service.show_many(["a", "b"]) == [sentinel.a]
+        client.show_many.assert_called_once_with(job_ids=["a", "b"])
+
+
+class TestWaitUntilComplete:
+    def test_returns_immediately_when_already_completed(self):
+        service, client = _make_service()
+        client.get.return_value = _make_status("completed")
+        sleep = Mock()
+        result = service.wait_until_complete(
+            "abc", interval=0.1, timeout=5.0, sleep=sleep
+        )
+        assert result.status == "completed"
+        sleep.assert_not_called()
+
+    def test_polls_until_terminal_state(self):
+        service, client = _make_service()
+        client.get.side_effect = [
+            _make_status("queued"),
+            _make_status("working"),
+            _make_status("completed"),
+        ]
+        sleep = Mock()
+        result = service.wait_until_complete(
+            "abc", interval=0.1, timeout=5.0, sleep=sleep
+        )
+        assert result.status == "completed"
+        assert sleep.call_count == 2
+
+    @pytest.mark.parametrize("terminal", ["completed", "failed", "killed"])
+    def test_treats_failed_and_killed_as_terminal(self, terminal):
+        service, client = _make_service()
+        client.get.return_value = _make_status(terminal)
+        result = service.wait_until_complete(
+            "abc", interval=0.1, timeout=5.0, sleep=Mock()
+        )
+        assert result.status == terminal
+
+    def test_raises_timeout_when_never_terminal(self):
+        service, client = _make_service()
+        client.get.return_value = _make_status("working")
+        # now() returns an ever-growing sequence so deadline is quickly exceeded
+        now_values = iter([0.0, 10.0, 20.0])
+        with pytest.raises(JobStatusTimeout):
+            service.wait_until_complete(
+                "abc",
+                interval=0.1,
+                timeout=5.0,
+                sleep=Mock(),
+                now=lambda: next(now_values),
+            )
+
+    def test_uses_injected_sleep(self):
+        service, client = _make_service()
+        client.get.side_effect = [
+            _make_status("queued"),
+            _make_status("completed"),
+        ]
+        sleep = Mock()
+        service.wait_until_complete(
+            "abc", interval=0.42, timeout=5.0, sleep=sleep
+        )
+        sleep.assert_called_once_with(0.42)
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_get_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.get.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.get_by_id("abc")


### PR DESCRIPTION
## Summary
- Adds `JobStatusApiClient` + `JobStatusesService` covering Zendesk job-statuses: `list`, `get`, `show_many` (via `?ids=a,b`).
- Adds a `wait_until_complete(job_id, interval, timeout)` polling helper that loops on `.get` until the job reaches a terminal state (`completed`, `failed`, `killed`) or raises `JobStatusTimeout`. `sleep` and `now` are injectable for deterministic testing.
- Reuses the existing shared `JobStatus` value object — no new domain model needed.
- Wires `self.job_statuses` onto the `Ticketing` facade.

## Test plan
- [x] Unit: `tests/unit/ticketing/test_job_status_client.py` — paths, show_many list/null/missing handling, error propagation
- [x] Unit: `tests/unit/ticketing/test_job_statuses_service.py` — delegation, poll-until-terminal, timeout, injected sleep/now, all three terminal states
- [x] Coverage: 100% on both new modules (44 statements)
- [x] Full unit suite passes (596 tests)
- [ ] Live-tenant integration: `tests/integration/ticketing/test_job_statuses.py` (list, NotFound for bogus id, wait_until_complete on an already-finished job)

Part of #79 (Batch 2 — job statuses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)