### PR TITLE
feat(ticketing): add satisfaction ratings + reasons

### DIFF
--- a/libzapi/application/commands/ticketing/satisfaction_rating_cmds.py
+++ b/libzapi/application/commands/ticketing/satisfaction_rating_cmds.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class CreateSatisfactionRatingCmd:
+    score: str
+    comment: str | None = None
+    reason_id: int | None = None

--- a/libzapi/application/services/ticketing/__init__.py
+++ b/libzapi/application/services/ticketing/__init__.py
@@ -12,6 +12,9 @@ from libzapi.application.services.ticketing.group_memberships_service import (
 from libzapi.application.services.ticketing.macro_service import MacroService
 from libzapi.application.services.ticketing.organizations_service import OrganizationsService
 from libzapi.application.services.ticketing.requests_service import RequestsService
+from libzapi.application.services.ticketing.satisfaction_ratings_service import (
+    SatisfactionRatingsService,
+)
 from libzapi.application.services.ticketing.schedule_service import ScheduleService
 from libzapi.application.services.ticketing.sessions_service import SessionsService
 from libzapi.application.services.ticketing.sla_policies_service import SlaPoliciesService
@@ -57,6 +60,9 @@ class Ticketing:
         self.macros = MacroService(api.MacroApiClient(http))
         self.organizations = OrganizationsService(api.OrganizationApiClient(http))
         self.requests = RequestsService(api.RequestApiClient(http))
+        self.satisfaction_ratings = SatisfactionRatingsService(
+            api.SatisfactionRatingApiClient(http)
+        )
         self.schedules = ScheduleService(api.ScheduleApiClient(http))
         self.sessions = SessionsService(api.SessionApiClient(http))
         self.sla_policies = SlaPoliciesService(api.SlaPolicyApiClient(http))

--- a/libzapi/application/services/ticketing/satisfaction_ratings_service.py
+++ b/libzapi/application/services/ticketing/satisfaction_ratings_service.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from libzapi.application.commands.ticketing.satisfaction_rating_cmds import (
+    CreateSatisfactionRatingCmd,
+)
+from libzapi.domain.models.ticketing.satisfaction_rating import (
+    SatisfactionRating,
+    SatisfactionReason,
+)
+from libzapi.infrastructure.api_clients.ticketing.satisfaction_rating_api_client import (
+    SatisfactionRatingApiClient,
+)
+
+
+class SatisfactionRatingsService:
+    """High-level service for Zendesk Satisfaction Ratings + Reasons."""
+
+    def __init__(self, client: SatisfactionRatingApiClient) -> None:
+        self._client = client
+
+    def list_all(
+        self,
+        *,
+        score: str | None = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
+    ) -> Iterable[SatisfactionRating]:
+        return self._client.list(score=score, start_time=start_time, end_time=end_time)
+
+    def list_received(self) -> Iterable[SatisfactionRating]:
+        return self._client.list_received()
+
+    def get_by_id(self, rating_id: int) -> SatisfactionRating:
+        return self._client.get(rating_id=rating_id)
+
+    def create_for_ticket(
+        self,
+        ticket_id: int,
+        score: str,
+        comment: str | None = None,
+        reason_id: int | None = None,
+    ) -> SatisfactionRating:
+        return self._client.create_for_ticket(
+            ticket_id=ticket_id,
+            entity=CreateSatisfactionRatingCmd(
+                score=score, comment=comment, reason_id=reason_id
+            ),
+        )
+
+    def list_reasons(self) -> Iterable[SatisfactionReason]:
+        return self._client.list_reasons()
+
+    def get_reason(self, reason_id: int) -> SatisfactionReason:
+        return self._client.get_reason(reason_id=reason_id)

--- a/libzapi/domain/models/ticketing/satisfaction_rating.py
+++ b/libzapi/domain/models/ticketing/satisfaction_rating.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from libzapi.domain.shared_objects.logical_key import LogicalKey
+
+
+@dataclass(frozen=True, slots=True)
+class SatisfactionRating:
+    id: int
+    score: str
+    ticket_id: int
+    created_at: datetime
+    updated_at: datetime
+    url: Optional[str] = None
+    assignee_id: Optional[int] = None
+    group_id: Optional[int] = None
+    requester_id: Optional[int] = None
+    comment: Optional[str] = None
+    reason: Optional[str] = None
+    reason_id: Optional[int] = None
+    reason_code: Optional[int] = None
+
+    @property
+    def logical_key(self) -> LogicalKey:
+        return LogicalKey("satisfaction_rating", f"rating_id_{self.id}")
+
+
+@dataclass(frozen=True, slots=True)
+class SatisfactionReason:
+    id: int
+    reason_code: int
+    raw_reason: dict
+    reason: dict
+    value: str
+    created_at: datetime
+    updated_at: datetime
+    url: Optional[str] = None
+
+    @property
+    def logical_key(self) -> LogicalKey:
+        return LogicalKey("satisfaction_reason", f"reason_id_{self.id}")

--- a/libzapi/infrastructure/api_clients/ticketing/__init__.py
+++ b/libzapi/infrastructure/api_clients/ticketing/__init__.py
@@ -11,6 +11,9 @@ from libzapi.infrastructure.api_clients.ticketing.group_membership_api_client im
 from libzapi.infrastructure.api_clients.ticketing.macro_api_client import MacroApiClient
 from libzapi.infrastructure.api_clients.ticketing.organization_api_client import OrganizationApiClient
 from libzapi.infrastructure.api_clients.ticketing.request_api_client import RequestApiClient
+from libzapi.infrastructure.api_clients.ticketing.satisfaction_rating_api_client import (
+    SatisfactionRatingApiClient,
+)
 from libzapi.infrastructure.api_clients.ticketing.schedule_api_client import ScheduleApiClient
 from libzapi.infrastructure.api_clients.ticketing.session_api_client import SessionApiClient
 from libzapi.infrastructure.api_clients.ticketing.sla_policy_api_client import SlaPolicyApiClient
@@ -43,6 +46,7 @@ __all__ = [
     "MacroApiClient",
     "OrganizationApiClient",
     "RequestApiClient",
+    "SatisfactionRatingApiClient",
     "ScheduleApiClient",
     "SessionApiClient",
     "SlaPolicyApiClient",

--- a/libzapi/infrastructure/api_clients/ticketing/satisfaction_rating_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/satisfaction_rating_api_client.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Iterator
+from urllib.parse import urlencode
+
+from libzapi.application.commands.ticketing.satisfaction_rating_cmds import (
+    CreateSatisfactionRatingCmd,
+)
+from libzapi.domain.models.ticketing.satisfaction_rating import (
+    SatisfactionRating,
+    SatisfactionReason,
+)
+from libzapi.infrastructure.http.client import HttpClient
+from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.mappers.ticketing.satisfaction_rating_mapper import (
+    to_payload_create,
+)
+from libzapi.infrastructure.serialization.parse import to_domain
+
+
+class SatisfactionRatingApiClient:
+    """HTTP adapter for Zendesk Satisfaction Ratings + Reasons."""
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def list(
+        self,
+        *,
+        score: str | None = None,
+        start_time: int | None = None,
+        end_time: int | None = None,
+    ) -> Iterator[SatisfactionRating]:
+        query: dict = {}
+        if score is not None:
+            query["score"] = score
+        if start_time is not None:
+            query["start_time"] = int(start_time)
+        if end_time is not None:
+            query["end_time"] = int(end_time)
+        path = "/api/v2/satisfaction_ratings"
+        if query:
+            path = f"{path}?{urlencode(query)}"
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path=path,
+            base_url=self._http.base_url,
+            items_key="satisfaction_ratings",
+        ):
+            yield to_domain(data=obj, cls=SatisfactionRating)
+
+    def list_received(self) -> Iterator[SatisfactionRating]:
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path="/api/v2/satisfaction_ratings/received",
+            base_url=self._http.base_url,
+            items_key="satisfaction_ratings",
+        ):
+            yield to_domain(data=obj, cls=SatisfactionRating)
+
+    def get(self, rating_id: int) -> SatisfactionRating:
+        data = self._http.get(f"/api/v2/satisfaction_ratings/{int(rating_id)}")
+        return to_domain(data=data["satisfaction_rating"], cls=SatisfactionRating)
+
+    def create_for_ticket(
+        self, ticket_id: int, entity: CreateSatisfactionRatingCmd
+    ) -> SatisfactionRating:
+        payload = to_payload_create(entity)
+        data = self._http.post(
+            f"/api/v2/tickets/{int(ticket_id)}/satisfaction_rating", payload
+        )
+        return to_domain(data=data["satisfaction_rating"], cls=SatisfactionRating)
+
+    def list_reasons(self) -> Iterator[SatisfactionReason]:
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path="/api/v2/satisfaction_reasons",
+            base_url=self._http.base_url,
+            items_key="reasons",
+        ):
+            yield to_domain(data=obj, cls=SatisfactionReason)
+
+    def get_reason(self, reason_id: int) -> SatisfactionReason:
+        data = self._http.get(f"/api/v2/satisfaction_reasons/{int(reason_id)}")
+        return to_domain(data=data["reason"], cls=SatisfactionReason)

--- a/libzapi/infrastructure/mappers/ticketing/satisfaction_rating_mapper.py
+++ b/libzapi/infrastructure/mappers/ticketing/satisfaction_rating_mapper.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from libzapi.application.commands.ticketing.satisfaction_rating_cmds import (
+    CreateSatisfactionRatingCmd,
+)
+
+
+def to_payload_create(cmd: CreateSatisfactionRatingCmd) -> dict:
+    body: dict = {"score": cmd.score}
+    if cmd.comment is not None:
+        body["comment"] = cmd.comment
+    if cmd.reason_id is not None:
+        body["reason_id"] = int(cmd.reason_id)
+    return {"satisfaction_rating": body}

--- a/tests/integration/ticketing/test_satisfaction_ratings.py
+++ b/tests/integration/ticketing/test_satisfaction_ratings.py
@@ -1,0 +1,48 @@
+import itertools
+
+from libzapi import Ticketing
+
+
+def test_list_all(ticketing: Ticketing):
+    items = list(itertools.islice(ticketing.satisfaction_ratings.list_all(), 50))
+    assert isinstance(items, list)
+
+
+def test_list_received(ticketing: Ticketing):
+    items = list(
+        itertools.islice(ticketing.satisfaction_ratings.list_received(), 50)
+    )
+    assert isinstance(items, list)
+
+
+def test_list_filter_by_score(ticketing: Ticketing):
+    items = list(
+        itertools.islice(
+            ticketing.satisfaction_ratings.list_all(score="received"), 50
+        )
+    )
+    assert isinstance(items, list)
+
+
+def test_list_reasons(ticketing: Ticketing):
+    reasons = list(itertools.islice(ticketing.satisfaction_ratings.list_reasons(), 50))
+    assert isinstance(reasons, list)
+    for reason in reasons:
+        assert reason.id > 0
+        assert reason.value is not None
+
+
+def test_get_first_rating(ticketing: Ticketing):
+    first = next(iter(ticketing.satisfaction_ratings.list_all()), None)
+    if first is None:
+        return
+    fetched = ticketing.satisfaction_ratings.get_by_id(first.id)
+    assert fetched.id == first.id
+
+
+def test_get_first_reason(ticketing: Ticketing):
+    first = next(iter(ticketing.satisfaction_ratings.list_reasons()), None)
+    if first is None:
+        return
+    fetched = ticketing.satisfaction_ratings.get_reason(first.id)
+    assert fetched.id == first.id

--- a/tests/unit/ticketing/test_satisfaction_rating.py
+++ b/tests/unit/ticketing/test_satisfaction_rating.py
@@ -1,0 +1,168 @@
+import pytest
+
+from libzapi.application.commands.ticketing.satisfaction_rating_cmds import (
+    CreateSatisfactionRatingCmd,
+)
+from libzapi.domain.errors import NotFound, RateLimited, Unauthorized, UnprocessableEntity
+from libzapi.infrastructure.api_clients.ticketing import SatisfactionRatingApiClient
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.satisfaction_rating_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+def test_list_no_filters_hits_base_path(http, domain):
+    http.get.return_value = {"satisfaction_ratings": []}
+    client = SatisfactionRatingApiClient(http)
+    list(client.list())
+    http.get.assert_called_with("/api/v2/satisfaction_ratings")
+
+
+def test_list_with_score_encodes_query(http, domain):
+    http.get.return_value = {"satisfaction_ratings": []}
+    client = SatisfactionRatingApiClient(http)
+    list(client.list(score="bad"))
+    http.get.assert_called_with("/api/v2/satisfaction_ratings?score=bad")
+
+
+def test_list_with_time_window(http, domain):
+    http.get.return_value = {"satisfaction_ratings": []}
+    client = SatisfactionRatingApiClient(http)
+    list(client.list(start_time=100, end_time=200))
+    http.get.assert_called_with(
+        "/api/v2/satisfaction_ratings?start_time=100&end_time=200"
+    )
+
+
+def test_list_yields_items(http, domain):
+    http.get.return_value = {
+        "satisfaction_ratings": [{"id": 1}, {"id": 2}],
+        "meta": {"has_more": False},
+        "links": {"next": None},
+    }
+    client = SatisfactionRatingApiClient(http)
+    assert len(list(client.list())) == 2
+
+
+def test_list_received(http, domain):
+    http.get.return_value = {"satisfaction_ratings": [{"id": 1}]}
+    client = SatisfactionRatingApiClient(http)
+    assert len(list(client.list_received())) == 1
+    http.get.assert_called_with("/api/v2/satisfaction_ratings/received")
+
+
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+
+def test_get_calls_endpoint(http, domain):
+    http.get.return_value = {"satisfaction_rating": {"id": 5}}
+    client = SatisfactionRatingApiClient(http)
+    client.get(rating_id=5)
+    http.get.assert_called_with("/api/v2/satisfaction_ratings/5")
+
+
+# ---------------------------------------------------------------------------
+# create_for_ticket
+# ---------------------------------------------------------------------------
+
+
+def test_create_for_ticket_posts_payload(http, domain):
+    http.post.return_value = {"satisfaction_rating": {"id": 1}}
+    client = SatisfactionRatingApiClient(http)
+    client.create_for_ticket(
+        ticket_id=42,
+        entity=CreateSatisfactionRatingCmd(score="good", comment="nice"),
+    )
+    http.post.assert_called_with(
+        "/api/v2/tickets/42/satisfaction_rating",
+        {"satisfaction_rating": {"score": "good", "comment": "nice"}},
+    )
+
+
+# ---------------------------------------------------------------------------
+# reasons
+# ---------------------------------------------------------------------------
+
+
+def test_list_reasons(http, domain):
+    http.get.return_value = {"reasons": [{"id": 1}, {"id": 2}]}
+    client = SatisfactionRatingApiClient(http)
+    assert len(list(client.list_reasons())) == 2
+    http.get.assert_called_with("/api/v2/satisfaction_reasons")
+
+
+def test_get_reason_calls_endpoint(http, domain):
+    http.get.return_value = {"reason": {"id": 5}}
+    client = SatisfactionRatingApiClient(http)
+    client.get_reason(reason_id=5)
+    http.get.assert_called_with("/api/v2/satisfaction_reasons/5")
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+)
+def test_raises_on_http_error(error_cls, http):
+    http.get.side_effect = error_cls("error")
+    client = SatisfactionRatingApiClient(http)
+    with pytest.raises(error_cls):
+        list(client.list())
+
+
+# ---------------------------------------------------------------------------
+# Domain logical keys
+# ---------------------------------------------------------------------------
+
+
+def test_satisfaction_rating_logical_key():
+    from datetime import datetime
+
+    from libzapi.domain.models.ticketing.satisfaction_rating import SatisfactionRating
+
+    r = SatisfactionRating(
+        id=1,
+        score="good",
+        ticket_id=42,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    assert r.logical_key.as_str() == "satisfaction_rating:rating_id_1"
+
+
+def test_satisfaction_reason_logical_key():
+    from datetime import datetime
+
+    from libzapi.domain.models.ticketing.satisfaction_rating import SatisfactionReason
+
+    r = SatisfactionReason(
+        id=9,
+        reason_code=100,
+        raw_reason={"value": "too slow"},
+        reason={"value": "too slow"},
+        value="too slow",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    assert r.logical_key.as_str() == "satisfaction_reason:reason_id_9"

--- a/tests/unit/ticketing/test_satisfaction_rating_mapper.py
+++ b/tests/unit/ticketing/test_satisfaction_rating_mapper.py
@@ -1,0 +1,57 @@
+from libzapi.application.commands.ticketing.satisfaction_rating_cmds import (
+    CreateSatisfactionRatingCmd,
+)
+from libzapi.infrastructure.mappers.ticketing.satisfaction_rating_mapper import (
+    to_payload_create,
+)
+
+
+def test_create_minimum_payload():
+    payload = to_payload_create(CreateSatisfactionRatingCmd(score="good"))
+    assert payload == {"satisfaction_rating": {"score": "good"}}
+
+
+def test_create_with_comment():
+    payload = to_payload_create(
+        CreateSatisfactionRatingCmd(score="bad", comment="not great")
+    )
+    assert payload == {
+        "satisfaction_rating": {"score": "bad", "comment": "not great"}
+    }
+
+
+def test_create_with_reason_id():
+    payload = to_payload_create(
+        CreateSatisfactionRatingCmd(score="bad", reason_id=7)
+    )
+    assert payload == {
+        "satisfaction_rating": {"score": "bad", "reason_id": 7}
+    }
+
+
+def test_create_full_payload():
+    payload = to_payload_create(
+        CreateSatisfactionRatingCmd(score="bad", comment="too slow", reason_id=9)
+    )
+    assert payload == {
+        "satisfaction_rating": {
+            "score": "bad",
+            "comment": "too slow",
+            "reason_id": 9,
+        }
+    }
+
+
+def test_create_empty_comment_is_preserved():
+    payload = to_payload_create(
+        CreateSatisfactionRatingCmd(score="good", comment="")
+    )
+    assert payload["satisfaction_rating"]["comment"] == ""
+
+
+def test_create_coerces_reason_id_to_int():
+    payload = to_payload_create(
+        CreateSatisfactionRatingCmd(score="bad", reason_id="5")  # type: ignore[arg-type]
+    )
+    assert isinstance(payload["satisfaction_rating"]["reason_id"], int)
+    assert payload["satisfaction_rating"]["reason_id"] == 5

--- a/tests/unit/ticketing/test_satisfaction_ratings_service.py
+++ b/tests/unit/ticketing/test_satisfaction_ratings_service.py
@@ -1,0 +1,97 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.commands.ticketing.satisfaction_rating_cmds import (
+    CreateSatisfactionRatingCmd,
+)
+from libzapi.application.services.ticketing.satisfaction_ratings_service import (
+    SatisfactionRatingsService,
+)
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return SatisfactionRatingsService(client), client
+
+
+class TestList:
+    def test_list_all_with_no_filters_delegates(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.ratings
+        assert service.list_all() is sentinel.ratings
+        client.list.assert_called_once_with(score=None, start_time=None, end_time=None)
+
+    def test_list_all_with_filters(self):
+        service, client = _make_service()
+        service.list_all(score="bad", start_time=1, end_time=2)
+        client.list.assert_called_once_with(score="bad", start_time=1, end_time=2)
+
+    def test_list_received_delegates(self):
+        service, client = _make_service()
+        client.list_received.return_value = sentinel.ratings
+        assert service.list_received() is sentinel.ratings
+        client.list_received.assert_called_once_with()
+
+
+class TestGet:
+    def test_get_by_id_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.rating
+        assert service.get_by_id(5) is sentinel.rating
+        client.get.assert_called_once_with(rating_id=5)
+
+
+class TestCreateForTicket:
+    def test_builds_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.create_for_ticket.return_value = sentinel.rating
+
+        result = service.create_for_ticket(
+            ticket_id=42, score="good", comment="nice"
+        )
+
+        call = client.create_for_ticket.call_args
+        assert call.kwargs["ticket_id"] == 42
+        cmd = call.kwargs["entity"]
+        assert isinstance(cmd, CreateSatisfactionRatingCmd)
+        assert cmd.score == "good"
+        assert cmd.comment == "nice"
+        assert cmd.reason_id is None
+        assert result is sentinel.rating
+
+    def test_forwards_reason_id(self):
+        service, client = _make_service()
+        service.create_for_ticket(ticket_id=1, score="bad", reason_id=7)
+        cmd = client.create_for_ticket.call_args.kwargs["entity"]
+        assert cmd.reason_id == 7
+
+
+class TestReasons:
+    def test_list_reasons_delegates(self):
+        service, client = _make_service()
+        client.list_reasons.return_value = sentinel.reasons
+        assert service.list_reasons() is sentinel.reasons
+        client.list_reasons.assert_called_once_with()
+
+    def test_get_reason_delegates(self):
+        service, client = _make_service()
+        client.get_reason.return_value = sentinel.reason
+        assert service.get_reason(9) is sentinel.reason
+        client.get_reason.assert_called_once_with(reason_id=9)
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.list.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list_all()
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_create_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.create_for_ticket.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.create_for_ticket(ticket_id=1, score="good")


### PR DESCRIPTION
## Summary
- Adds `SatisfactionRatingApiClient` + `SatisfactionRatingsService` with list (score/time filters), list_received, get, create_for_ticket, list_reasons, get_reason.
- Domain models `SatisfactionRating` and `SatisfactionReason` with logical keys (frozen, slots).
- Wires `satisfaction_ratings` onto the `Ticketing` facade.

## Test plan
- [x] Unit tests: 33 passing, 100% coverage on new domain/command/mapper/api-client/service modules.
- [x] Full unit suite still green (1887 tests).
- [ ] Integration tests against a live Zendesk tenant exercise list/get paths for ratings and reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)