### PR TITLE
feat(ticketing): add custom ticket statuses CRUD

### DIFF
--- a/libzapi/application/commands/ticketing/custom_ticket_status_cmds.py
+++ b/libzapi/application/commands/ticketing/custom_ticket_status_cmds.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TypeAlias
+
+
+@dataclass(frozen=True, slots=True)
+class CreateCustomTicketStatusCmd:
+    status_category: str
+    agent_label: str
+    end_user_label: str | None = None
+    description: str | None = None
+    end_user_description: str | None = None
+    active: bool | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateCustomTicketStatusCmd:
+    agent_label: str | None = None
+    end_user_label: str | None = None
+    description: str | None = None
+    end_user_description: str | None = None
+    active: bool | None = None
+
+
+CustomTicketStatusCmd: TypeAlias = (
+    CreateCustomTicketStatusCmd | UpdateCustomTicketStatusCmd
+)

--- a/libzapi/application/services/ticketing/__init__.py
+++ b/libzapi/application/services/ticketing/__init__.py
@@ -4,6 +4,9 @@ from libzapi.application.services.ticketing.attachments_service import Attachmen
 from libzapi.application.services.ticketing.automations_service import AutomationsService
 from libzapi.application.services.ticketing.brand_agents_service import BrandAgentsService
 from libzapi.application.services.ticketing.brands_service import BrandsService
+from libzapi.application.services.ticketing.custom_ticket_statuses_service import (
+    CustomTicketStatusesService,
+)
 from libzapi.application.services.ticketing.email_notifications_service import EmailNotificationService
 from libzapi.application.services.ticketing.groups_service import GroupsService
 from libzapi.application.services.ticketing.group_memberships_service import (
@@ -57,6 +60,9 @@ class Ticketing:
         self.automations = AutomationsService(api.AutomationApiClient(http))
         self.brands = BrandsService(api.BrandApiClient(http))
         self.brand_agents = BrandAgentsService(api.BrandAgentApiClient(http))
+        self.custom_ticket_statuses = CustomTicketStatusesService(
+            api.CustomTicketStatusApiClient(http)
+        )
         self.email_notifications = EmailNotificationService(api.EmailNotificationApiClient(http))
         self.groups = GroupsService(api.GroupApiClient(http))
         self.group_memberships = GroupMembershipsService(api.GroupMembershipApiClient(http))

--- a/libzapi/application/services/ticketing/custom_ticket_statuses_service.py
+++ b/libzapi/application/services/ticketing/custom_ticket_statuses_service.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from libzapi.application.commands.ticketing.custom_ticket_status_cmds import (
+    CreateCustomTicketStatusCmd,
+    UpdateCustomTicketStatusCmd,
+)
+from libzapi.domain.models.ticketing.custom_ticket_status import CustomTicketStatus
+from libzapi.infrastructure.api_clients.ticketing.custom_ticket_status_api_client import (
+    CustomTicketStatusApiClient,
+)
+
+
+class CustomTicketStatusesService:
+    """High-level service for Zendesk Custom Ticket Statuses."""
+
+    def __init__(self, client: CustomTicketStatusApiClient) -> None:
+        self._client = client
+
+    def list_all(
+        self,
+        *,
+        status_categories: Iterable[str] | None = None,
+        active: bool | None = None,
+        default: bool | None = None,
+    ) -> Iterable[CustomTicketStatus]:
+        return self._client.list(
+            status_categories=status_categories, active=active, default=default
+        )
+
+    def get_by_id(self, status_id: int) -> CustomTicketStatus:
+        return self._client.get(status_id=status_id)
+
+    def create(
+        self,
+        status_category: str,
+        agent_label: str,
+        **fields,
+    ) -> CustomTicketStatus:
+        return self._client.create(
+            entity=CreateCustomTicketStatusCmd(
+                status_category=status_category,
+                agent_label=agent_label,
+                **fields,
+            )
+        )
+
+    def update(self, status_id: int, **fields) -> CustomTicketStatus:
+        return self._client.update(
+            status_id=status_id,
+            entity=UpdateCustomTicketStatusCmd(**fields),
+        )

--- a/libzapi/domain/models/ticketing/custom_ticket_status.py
+++ b/libzapi/domain/models/ticketing/custom_ticket_status.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional
+
+from libzapi.domain.shared_objects.logical_key import LogicalKey
+
+
+@dataclass(frozen=True, slots=True)
+class CustomTicketStatus:
+    id: int
+    status_category: str
+    agent_label: str
+    end_user_label: str
+    created_at: datetime
+    updated_at: datetime
+    active: bool = True
+    default: bool = False
+    description: Optional[str] = None
+    end_user_description: Optional[str] = None
+    raw_agent_label: Optional[str] = None
+    raw_description: Optional[str] = None
+    raw_end_user_description: Optional[str] = None
+    raw_end_user_label: Optional[str] = None
+    url: Optional[str] = None
+    excluded_from_forms: List[int] = field(default_factory=list)
+
+    @property
+    def logical_key(self) -> LogicalKey:
+        return LogicalKey("custom_ticket_status", f"status_id_{self.id}")

--- a/libzapi/infrastructure/api_clients/ticketing/__init__.py
+++ b/libzapi/infrastructure/api_clients/ticketing/__init__.py
@@ -3,6 +3,9 @@ from libzapi.infrastructure.api_clients.ticketing.attachment_api_client import A
 from libzapi.infrastructure.api_clients.ticketing.automation_api_client import AutomationApiClient
 from libzapi.infrastructure.api_clients.ticketing.brand_api_client import BrandApiClient
 from libzapi.infrastructure.api_clients.ticketing.brand_agent_api_client import BrandAgentApiClient
+from libzapi.infrastructure.api_clients.ticketing.custom_ticket_status_api_client import (
+    CustomTicketStatusApiClient,
+)
 from libzapi.infrastructure.api_clients.ticketing.email_notification_api_client import EmailNotificationApiClient
 from libzapi.infrastructure.api_clients.ticketing.group_api_client import GroupApiClient
 from libzapi.infrastructure.api_clients.ticketing.group_membership_api_client import (
@@ -43,6 +46,7 @@ __all__ = [
     "AutomationApiClient",
     "BrandApiClient",
     "BrandAgentApiClient",
+    "CustomTicketStatusApiClient",
     "EmailNotificationApiClient",
     "GroupApiClient",
     "GroupMembershipApiClient",

--- a/libzapi/infrastructure/api_clients/ticketing/custom_ticket_status_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/custom_ticket_status_api_client.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+from urllib.parse import urlencode
+
+from libzapi.application.commands.ticketing.custom_ticket_status_cmds import (
+    CreateCustomTicketStatusCmd,
+    UpdateCustomTicketStatusCmd,
+)
+from libzapi.domain.models.ticketing.custom_ticket_status import CustomTicketStatus
+from libzapi.infrastructure.http.client import HttpClient
+from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.mappers.ticketing.custom_ticket_status_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
+from libzapi.infrastructure.serialization.parse import to_domain
+
+
+class CustomTicketStatusApiClient:
+    """HTTP adapter for Zendesk Custom Ticket Statuses."""
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def list(
+        self,
+        *,
+        status_categories: Iterable[str] | None = None,
+        active: bool | None = None,
+        default: bool | None = None,
+    ) -> Iterator[CustomTicketStatus]:
+        query: dict = {}
+        if status_categories is not None:
+            query["status_categories"] = ",".join(status_categories)
+        if active is not None:
+            query["active"] = "true" if active else "false"
+        if default is not None:
+            query["default"] = "true" if default else "false"
+        path = "/api/v2/custom_statuses"
+        if query:
+            path = f"{path}?{urlencode(query)}"
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path=path,
+            base_url=self._http.base_url,
+            items_key="custom_statuses",
+        ):
+            yield to_domain(data=obj, cls=CustomTicketStatus)
+
+    def get(self, status_id: int) -> CustomTicketStatus:
+        data = self._http.get(f"/api/v2/custom_statuses/{int(status_id)}")
+        return to_domain(data=data["custom_status"], cls=CustomTicketStatus)
+
+    def create(self, entity: CreateCustomTicketStatusCmd) -> CustomTicketStatus:
+        payload = to_payload_create(entity)
+        data = self._http.post("/api/v2/custom_statuses", payload)
+        return to_domain(data=data["custom_status"], cls=CustomTicketStatus)
+
+    def update(
+        self, status_id: int, entity: UpdateCustomTicketStatusCmd
+    ) -> CustomTicketStatus:
+        payload = to_payload_update(entity)
+        data = self._http.put(
+            f"/api/v2/custom_statuses/{int(status_id)}", payload
+        )
+        return to_domain(data=data["custom_status"], cls=CustomTicketStatus)

--- a/libzapi/infrastructure/mappers/ticketing/custom_ticket_status_mapper.py
+++ b/libzapi/infrastructure/mappers/ticketing/custom_ticket_status_mapper.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from libzapi.application.commands.ticketing.custom_ticket_status_cmds import (
+    CreateCustomTicketStatusCmd,
+    UpdateCustomTicketStatusCmd,
+)
+
+
+_OPTIONAL_STRING_FIELDS = (
+    "end_user_label",
+    "description",
+    "end_user_description",
+)
+
+
+def to_payload_create(cmd: CreateCustomTicketStatusCmd) -> dict:
+    body: dict = {
+        "status_category": cmd.status_category,
+        "agent_label": cmd.agent_label,
+    }
+    for name in _OPTIONAL_STRING_FIELDS:
+        value = getattr(cmd, name)
+        if value is not None:
+            body[name] = value
+    if cmd.active is not None:
+        body["active"] = cmd.active
+    return {"custom_status": body}
+
+
+def to_payload_update(cmd: UpdateCustomTicketStatusCmd) -> dict:
+    body: dict = {}
+    if cmd.agent_label is not None:
+        body["agent_label"] = cmd.agent_label
+    for name in _OPTIONAL_STRING_FIELDS:
+        value = getattr(cmd, name)
+        if value is not None:
+            body[name] = value
+    if cmd.active is not None:
+        body["active"] = cmd.active
+    return {"custom_status": body}

--- a/tests/integration/ticketing/test_custom_ticket_statuses.py
+++ b/tests/integration/ticketing/test_custom_ticket_statuses.py
@@ -1,0 +1,57 @@
+import itertools
+import uuid
+
+from libzapi import Ticketing
+
+
+def _unique() -> str:
+    return uuid.uuid4().hex[:10]
+
+
+def test_list_all(ticketing: Ticketing):
+    items = list(itertools.islice(ticketing.custom_ticket_statuses.list_all(), 100))
+    assert isinstance(items, list)
+
+
+def test_list_with_category_filter(ticketing: Ticketing):
+    items = list(
+        itertools.islice(
+            ticketing.custom_ticket_statuses.list_all(status_categories=["open"]),
+            50,
+        )
+    )
+    assert isinstance(items, list)
+    for item in items:
+        assert item.status_category == "open"
+
+
+def test_list_with_active_filter(ticketing: Ticketing):
+    items = list(
+        itertools.islice(
+            ticketing.custom_ticket_statuses.list_all(active=True), 50
+        )
+    )
+    assert isinstance(items, list)
+    for item in items:
+        assert item.active is True
+
+
+def test_create_update_and_fetch(ticketing: Ticketing):
+    label = f"libzapi {_unique()}"
+    created = ticketing.custom_ticket_statuses.create(
+        status_category="pending",
+        agent_label=label,
+        end_user_label=label,
+        description="created by libzapi integration test",
+    )
+    try:
+        assert created.id > 0
+        assert created.agent_label == label
+        fetched = ticketing.custom_ticket_statuses.get_by_id(created.id)
+        assert fetched.id == created.id
+        updated = ticketing.custom_ticket_statuses.update(
+            status_id=created.id, agent_label=f"{label} updated"
+        )
+        assert updated.agent_label.endswith("updated")
+    finally:
+        ticketing.custom_ticket_statuses.update(status_id=created.id, active=False)

--- a/tests/unit/ticketing/test_custom_ticket_status.py
+++ b/tests/unit/ticketing/test_custom_ticket_status.py
@@ -1,0 +1,164 @@
+import pytest
+
+from libzapi.application.commands.ticketing.custom_ticket_status_cmds import (
+    CreateCustomTicketStatusCmd,
+    UpdateCustomTicketStatusCmd,
+)
+from libzapi.domain.errors import NotFound, RateLimited, Unauthorized, UnprocessableEntity
+from libzapi.infrastructure.api_clients.ticketing import CustomTicketStatusApiClient
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.custom_ticket_status_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+def test_list_no_filters(http, domain):
+    http.get.return_value = {"custom_statuses": []}
+    client = CustomTicketStatusApiClient(http)
+    list(client.list())
+    http.get.assert_called_with("/api/v2/custom_statuses")
+
+
+def test_list_with_status_categories(http, domain):
+    http.get.return_value = {"custom_statuses": []}
+    client = CustomTicketStatusApiClient(http)
+    list(client.list(status_categories=["open", "pending"]))
+    http.get.assert_called_with(
+        "/api/v2/custom_statuses?status_categories=open%2Cpending"
+    )
+
+
+def test_list_with_active_filter(http, domain):
+    http.get.return_value = {"custom_statuses": []}
+    client = CustomTicketStatusApiClient(http)
+    list(client.list(active=True))
+    http.get.assert_called_with("/api/v2/custom_statuses?active=true")
+
+
+def test_list_with_active_false(http, domain):
+    http.get.return_value = {"custom_statuses": []}
+    client = CustomTicketStatusApiClient(http)
+    list(client.list(active=False))
+    http.get.assert_called_with("/api/v2/custom_statuses?active=false")
+
+
+def test_list_with_default_filter(http, domain):
+    http.get.return_value = {"custom_statuses": []}
+    client = CustomTicketStatusApiClient(http)
+    list(client.list(default=True))
+    http.get.assert_called_with("/api/v2/custom_statuses?default=true")
+
+
+def test_list_with_default_false(http, domain):
+    http.get.return_value = {"custom_statuses": []}
+    client = CustomTicketStatusApiClient(http)
+    list(client.list(default=False))
+    http.get.assert_called_with("/api/v2/custom_statuses?default=false")
+
+
+def test_list_yields_items(http, domain):
+    http.get.return_value = {
+        "custom_statuses": [{"id": 1}, {"id": 2}],
+        "meta": {"has_more": False},
+        "links": {"next": None},
+    }
+    client = CustomTicketStatusApiClient(http)
+    assert len(list(client.list())) == 2
+
+
+# ---------------------------------------------------------------------------
+# get
+# ---------------------------------------------------------------------------
+
+
+def test_get_calls_endpoint(http, domain):
+    http.get.return_value = {"custom_status": {"id": 5}}
+    client = CustomTicketStatusApiClient(http)
+    client.get(status_id=5)
+    http.get.assert_called_with("/api/v2/custom_statuses/5")
+
+
+# ---------------------------------------------------------------------------
+# create
+# ---------------------------------------------------------------------------
+
+
+def test_create_posts_payload(http, domain):
+    http.post.return_value = {"custom_status": {"id": 1}}
+    client = CustomTicketStatusApiClient(http)
+    client.create(
+        CreateCustomTicketStatusCmd(status_category="open", agent_label="Busy")
+    )
+    http.post.assert_called_with(
+        "/api/v2/custom_statuses",
+        {"custom_status": {"status_category": "open", "agent_label": "Busy"}},
+    )
+
+
+# ---------------------------------------------------------------------------
+# update
+# ---------------------------------------------------------------------------
+
+
+def test_update_puts_payload(http, domain):
+    http.put.return_value = {"custom_status": {"id": 7}}
+    client = CustomTicketStatusApiClient(http)
+    client.update(status_id=7, entity=UpdateCustomTicketStatusCmd(agent_label="New"))
+    http.put.assert_called_with(
+        "/api/v2/custom_statuses/7",
+        {"custom_status": {"agent_label": "New"}},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+)
+def test_raises_on_http_error(error_cls, http):
+    http.get.side_effect = error_cls("error")
+    client = CustomTicketStatusApiClient(http)
+    with pytest.raises(error_cls):
+        list(client.list())
+
+
+# ---------------------------------------------------------------------------
+# Domain logical key
+# ---------------------------------------------------------------------------
+
+
+def test_custom_ticket_status_logical_key():
+    from datetime import datetime
+
+    from libzapi.domain.models.ticketing.custom_ticket_status import (
+        CustomTicketStatus,
+    )
+
+    status = CustomTicketStatus(
+        id=42,
+        status_category="open",
+        agent_label="Being worked",
+        end_user_label="In progress",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    assert status.logical_key.as_str() == "custom_ticket_status:status_id_42"

--- a/tests/unit/ticketing/test_custom_ticket_status_mapper.py
+++ b/tests/unit/ticketing/test_custom_ticket_status_mapper.py
@@ -1,0 +1,104 @@
+from libzapi.application.commands.ticketing.custom_ticket_status_cmds import (
+    CreateCustomTicketStatusCmd,
+    UpdateCustomTicketStatusCmd,
+)
+from libzapi.infrastructure.mappers.ticketing.custom_ticket_status_mapper import (
+    to_payload_create,
+    to_payload_update,
+)
+
+
+def test_create_minimum_payload():
+    payload = to_payload_create(
+        CreateCustomTicketStatusCmd(status_category="open", agent_label="In Progress")
+    )
+    assert payload == {
+        "custom_status": {
+            "status_category": "open",
+            "agent_label": "In Progress",
+        }
+    }
+
+
+def test_create_with_all_fields():
+    payload = to_payload_create(
+        CreateCustomTicketStatusCmd(
+            status_category="open",
+            agent_label="In Progress",
+            end_user_label="Being worked",
+            description="agent desc",
+            end_user_description="eu desc",
+            active=True,
+        )
+    )
+    assert payload == {
+        "custom_status": {
+            "status_category": "open",
+            "agent_label": "In Progress",
+            "end_user_label": "Being worked",
+            "description": "agent desc",
+            "end_user_description": "eu desc",
+            "active": True,
+        }
+    }
+
+
+def test_create_preserves_false_active():
+    payload = to_payload_create(
+        CreateCustomTicketStatusCmd(
+            status_category="open", agent_label="x", active=False
+        )
+    )
+    assert payload["custom_status"]["active"] is False
+
+
+def test_create_omits_none_fields():
+    payload = to_payload_create(
+        CreateCustomTicketStatusCmd(
+            status_category="open",
+            agent_label="x",
+            end_user_label=None,
+            description=None,
+            active=None,
+        )
+    )
+    body = payload["custom_status"]
+    assert "end_user_label" not in body
+    assert "description" not in body
+    assert "active" not in body
+
+
+def test_update_empty_returns_empty_body():
+    payload = to_payload_update(UpdateCustomTicketStatusCmd())
+    assert payload == {"custom_status": {}}
+
+
+def test_update_with_agent_label():
+    payload = to_payload_update(UpdateCustomTicketStatusCmd(agent_label="New"))
+    assert payload == {"custom_status": {"agent_label": "New"}}
+
+
+def test_update_with_all_fields():
+    payload = to_payload_update(
+        UpdateCustomTicketStatusCmd(
+            agent_label="a",
+            end_user_label="b",
+            description="c",
+            end_user_description="d",
+            active=False,
+        )
+    )
+    assert payload == {
+        "custom_status": {
+            "agent_label": "a",
+            "end_user_label": "b",
+            "description": "c",
+            "end_user_description": "d",
+            "active": False,
+        }
+    }
+
+
+def test_update_preserves_false_active():
+    payload = to_payload_update(UpdateCustomTicketStatusCmd(active=False))
+    assert payload["custom_status"]["active"] is False

--- a/tests/unit/ticketing/test_custom_ticket_statuses_service.py
+++ b/tests/unit/ticketing/test_custom_ticket_statuses_service.py
@@ -1,0 +1,107 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.commands.ticketing.custom_ticket_status_cmds import (
+    CreateCustomTicketStatusCmd,
+    UpdateCustomTicketStatusCmd,
+)
+from libzapi.application.services.ticketing.custom_ticket_statuses_service import (
+    CustomTicketStatusesService,
+)
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return CustomTicketStatusesService(client), client
+
+
+class TestList:
+    def test_list_all_no_filters(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.items
+        assert service.list_all() is sentinel.items
+        client.list.assert_called_once_with(
+            status_categories=None, active=None, default=None
+        )
+
+    def test_list_all_with_filters(self):
+        service, client = _make_service()
+        service.list_all(status_categories=["open"], active=True, default=False)
+        client.list.assert_called_once_with(
+            status_categories=["open"], active=True, default=False
+        )
+
+
+class TestGet:
+    def test_get_by_id_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.status
+        assert service.get_by_id(5) is sentinel.status
+        client.get.assert_called_once_with(status_id=5)
+
+
+class TestCreate:
+    def test_builds_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.create.return_value = sentinel.status
+
+        result = service.create(
+            status_category="open",
+            agent_label="Working",
+            end_user_label="In progress",
+        )
+
+        cmd = client.create.call_args.kwargs["entity"]
+        assert isinstance(cmd, CreateCustomTicketStatusCmd)
+        assert cmd.status_category == "open"
+        assert cmd.agent_label == "Working"
+        assert cmd.end_user_label == "In progress"
+        assert result is sentinel.status
+
+    def test_accepts_active_flag(self):
+        service, client = _make_service()
+        service.create(status_category="open", agent_label="x", active=True)
+        cmd = client.create.call_args.kwargs["entity"]
+        assert cmd.active is True
+
+
+class TestUpdate:
+    def test_builds_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.update.return_value = sentinel.status
+
+        result = service.update(status_id=7, agent_label="New label")
+
+        call = client.update.call_args
+        assert call.kwargs["status_id"] == 7
+        cmd = call.kwargs["entity"]
+        assert isinstance(cmd, UpdateCustomTicketStatusCmd)
+        assert cmd.agent_label == "New label"
+        assert result is sentinel.status
+
+    def test_empty_update(self):
+        service, client = _make_service()
+        service.update(status_id=7)
+        cmd = client.update.call_args.kwargs["entity"]
+        assert cmd.agent_label is None
+        assert cmd.end_user_label is None
+        assert cmd.description is None
+        assert cmd.end_user_description is None
+        assert cmd.active is None
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.list.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list_all()
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_create_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.create.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.create(status_category="open", agent_label="x")


### PR DESCRIPTION
## Summary
- Adds `CustomTicketStatusApiClient` + `CustomTicketStatusesService` with list (filterable by `status_categories`, `active`, `default`), get, create, and update.
- Domain model `CustomTicketStatus` with logical key (frozen, slots).
- Wires `custom_ticket_statuses` onto the `Ticketing` facade.

## Test plan
- [x] Unit tests: 34 passing, 100% coverage on new domain/command/mapper/api-client/service modules.
- [x] Full unit suite still green.
- [ ] Integration tests against a live Zendesk tenant exercise list/filter/create/update paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)