### PR TITLE
feat(ticketing): add ticket activities list + get

### DIFF
--- a/libzapi/application/services/ticketing/__init__.py
+++ b/libzapi/application/services/ticketing/__init__.py
@@ -23,6 +23,9 @@ from libzapi.application.services.ticketing.support_addresses_service import Sup
 from libzapi.application.services.ticketing.suspended_tickets_service import SuspendedTicketsService
 from libzapi.application.services.ticketing.tags_service import TagsService
 from libzapi.application.services.ticketing.tickets_service import TickestService
+from libzapi.application.services.ticketing.ticket_activities_service import (
+    TicketActivitiesService,
+)
 from libzapi.application.services.ticketing.ticket_audits_service import TicketAuditsService
 from libzapi.application.services.ticketing.ticket_comments_service import TicketCommentsService
 from libzapi.application.services.ticketing.ticket_fields_service import TicketFieldsService
@@ -75,6 +78,9 @@ class Ticketing:
         self.suspended_tickets = SuspendedTicketsService(api.SuspendedTicketApiClient(http))
         self.tags = TagsService(api.TagApiClient(http))
         self.tickets = TickestService(api.TicketApiClient(http))
+        self.ticket_activities = TicketActivitiesService(
+            api.TicketActivityApiClient(http)
+        )
         self.ticket_audits = TicketAuditsService(api.TicketAuditApiClient(http))
         self.ticket_comments = TicketCommentsService(api.TicketCommentApiClient(http))
         self.ticket_fields = TicketFieldsService(api.TicketFieldApiClient(http))

--- a/libzapi/application/services/ticketing/ticket_activities_service.py
+++ b/libzapi/application/services/ticketing/ticket_activities_service.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from libzapi.domain.models.ticketing.ticket_activity import TicketActivity
+from libzapi.infrastructure.api_clients.ticketing.ticket_activity_api_client import (
+    TicketActivityApiClient,
+)
+
+
+class TicketActivitiesService:
+    """High-level service for Zendesk Ticket Activities."""
+
+    def __init__(self, client: TicketActivityApiClient) -> None:
+        self._client = client
+
+    def list_all(
+        self, *, since: str | None = None, include: str | None = None
+    ) -> Iterable[TicketActivity]:
+        return self._client.list(since=since, include=include)
+
+    def get_by_id(self, activity_id: int) -> TicketActivity:
+        return self._client.get(activity_id=activity_id)

--- a/libzapi/domain/models/ticketing/ticket_activity.py
+++ b/libzapi/domain/models/ticketing/ticket_activity.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from libzapi.domain.shared_objects.logical_key import LogicalKey
+
+
+@dataclass(frozen=True, slots=True)
+class TicketActivity:
+    id: int
+    verb: str
+    title: str
+    created_at: datetime
+    updated_at: datetime
+    user_id: Optional[int] = None
+    actor_id: Optional[int] = None
+    url: Optional[str] = None
+    actor: Optional[dict] = None
+    user: Optional[dict] = None
+    object: Optional[dict] = None
+    target: Optional[dict] = None
+
+    @property
+    def logical_key(self) -> LogicalKey:
+        return LogicalKey("ticket_activity", f"activity_id_{self.id}")

--- a/libzapi/infrastructure/api_clients/ticketing/__init__.py
+++ b/libzapi/infrastructure/api_clients/ticketing/__init__.py
@@ -28,6 +28,7 @@ from libzapi.infrastructure.api_clients.ticketing.ticket_field_api_client import
 from libzapi.infrastructure.api_clients.ticketing.ticket_form_api_client import TicketFormApiClient
 from libzapi.infrastructure.api_clients.ticketing.ticket_metric_api_client import TicketMetricApiClient
 from libzapi.infrastructure.api_clients.ticketing.ticket_metric_event_api_client import TicketMetricEventApiClient
+from libzapi.infrastructure.api_clients.ticketing.ticket_activity_api_client import TicketActivityApiClient
 from libzapi.infrastructure.api_clients.ticketing.ticket_trigger_api_client import TicketTriggerApiClient
 from libzapi.infrastructure.api_clients.ticketing.ticket_trigger_category_api_client import (
     TicketTriggerCategoryApiClient,
@@ -59,6 +60,7 @@ __all__ = [
     "SuspendedTicketApiClient",
     "TagApiClient",
     "TicketApiClient",
+    "TicketActivityApiClient",
     "TicketAuditApiClient",
     "TicketCommentApiClient",
     "TicketFieldApiClient",

--- a/libzapi/infrastructure/api_clients/ticketing/ticket_activity_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/ticket_activity_api_client.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import Iterator
+from urllib.parse import urlencode
+
+from libzapi.domain.models.ticketing.ticket_activity import TicketActivity
+from libzapi.infrastructure.http.client import HttpClient
+from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.serialization.parse import to_domain
+
+
+class TicketActivityApiClient:
+    """HTTP adapter for Zendesk Ticket Activities."""
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def list(
+        self, *, since: str | None = None, include: str | None = None
+    ) -> Iterator[TicketActivity]:
+        query: dict = {}
+        if since is not None:
+            query["since"] = since
+        if include is not None:
+            query["include"] = include
+        path = "/api/v2/activities"
+        if query:
+            path = f"{path}?{urlencode(query)}"
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path=path,
+            base_url=self._http.base_url,
+            items_key="activities",
+        ):
+            yield to_domain(data=obj, cls=TicketActivity)
+
+    def get(self, activity_id: int) -> TicketActivity:
+        data = self._http.get(f"/api/v2/activities/{int(activity_id)}")
+        return to_domain(data=data["activity"], cls=TicketActivity)

--- a/tests/integration/ticketing/test_ticket_activities.py
+++ b/tests/integration/ticketing/test_ticket_activities.py
@@ -1,0 +1,25 @@
+import itertools
+
+from libzapi import Ticketing
+
+
+def test_list_all(ticketing: Ticketing):
+    items = list(itertools.islice(ticketing.ticket_activities.list_all(), 20))
+    assert isinstance(items, list)
+
+
+def test_list_with_include(ticketing: Ticketing):
+    items = list(
+        itertools.islice(
+            ticketing.ticket_activities.list_all(include="users"), 20
+        )
+    )
+    assert isinstance(items, list)
+
+
+def test_get_first_activity(ticketing: Ticketing):
+    first = next(iter(ticketing.ticket_activities.list_all()), None)
+    if first is None:
+        return
+    fetched = ticketing.ticket_activities.get_by_id(first.id)
+    assert fetched.id == first.id

--- a/tests/unit/ticketing/test_ticket_activities_service.py
+++ b/tests/unit/ticketing/test_ticket_activities_service.py
@@ -1,0 +1,42 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.services.ticketing.ticket_activities_service import (
+    TicketActivitiesService,
+)
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return TicketActivitiesService(client), client
+
+
+class TestList:
+    def test_list_all_no_filters(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.items
+        assert service.list_all() is sentinel.items
+        client.list.assert_called_once_with(since=None, include=None)
+
+    def test_list_all_with_filters(self):
+        service, client = _make_service()
+        service.list_all(since="2026-04-21", include="users")
+        client.list.assert_called_once_with(since="2026-04-21", include="users")
+
+
+class TestGet:
+    def test_get_by_id_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.activity
+        assert service.get_by_id(5) is sentinel.activity
+        client.get.assert_called_once_with(activity_id=5)
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.list.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list_all()

--- a/tests/unit/ticketing/test_ticket_activity.py
+++ b/tests/unit/ticketing/test_ticket_activity.py
@@ -1,0 +1,95 @@
+import pytest
+
+from libzapi.domain.errors import NotFound, RateLimited, Unauthorized, UnprocessableEntity
+from libzapi.infrastructure.api_clients.ticketing import TicketActivityApiClient
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.ticket_activity_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+def test_list_no_filters(http, domain):
+    http.get.return_value = {"activities": []}
+    client = TicketActivityApiClient(http)
+    list(client.list())
+    http.get.assert_called_with("/api/v2/activities")
+
+
+def test_list_with_since(http, domain):
+    http.get.return_value = {"activities": []}
+    client = TicketActivityApiClient(http)
+    list(client.list(since="2026-04-21T00:00:00Z"))
+    http.get.assert_called_with(
+        "/api/v2/activities?since=2026-04-21T00%3A00%3A00Z"
+    )
+
+
+def test_list_with_include(http, domain):
+    http.get.return_value = {"activities": []}
+    client = TicketActivityApiClient(http)
+    list(client.list(include="users"))
+    http.get.assert_called_with("/api/v2/activities?include=users")
+
+
+def test_list_with_both_filters(http, domain):
+    http.get.return_value = {"activities": []}
+    client = TicketActivityApiClient(http)
+    list(client.list(since="2026-04-21", include="users"))
+    http.get.assert_called_with(
+        "/api/v2/activities?since=2026-04-21&include=users"
+    )
+
+
+def test_list_yields_items(http, domain):
+    http.get.return_value = {
+        "activities": [{"id": 1}, {"id": 2}],
+        "meta": {"has_more": False},
+        "links": {"next": None},
+    }
+    client = TicketActivityApiClient(http)
+    items = list(client.list())
+    assert len(items) == 2
+    assert all(i["_cls"] == "TicketActivity" for i in items)
+
+
+def test_get_calls_endpoint(http, domain):
+    http.get.return_value = {"activity": {"id": 5}}
+    client = TicketActivityApiClient(http)
+    client.get(activity_id=5)
+    http.get.assert_called_with("/api/v2/activities/5")
+
+
+@pytest.mark.parametrize(
+    "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+)
+def test_raises_on_http_error(error_cls, http):
+    http.get.side_effect = error_cls("error")
+    client = TicketActivityApiClient(http)
+    with pytest.raises(error_cls):
+        list(client.list())
+
+
+def test_ticket_activity_logical_key():
+    from datetime import datetime
+
+    from libzapi.domain.models.ticketing.ticket_activity import TicketActivity
+
+    act = TicketActivity(
+        id=7,
+        verb="tickets.assignment",
+        title="Assigned",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+    )
+    assert act.logical_key.as_str() == "ticket_activity:activity_id_7"


### PR DESCRIPTION
## Summary
- Adds `TicketActivityApiClient` + `TicketActivitiesService` with list (supports `since` and `include` filters) and get.
- Domain model `TicketActivity` with logical key (frozen, slots).
- Wires `ticket_activities` onto the `Ticketing` facade.

## Test plan
- [x] Unit tests: 16 passing, 100% coverage on new modules.
- [x] Full unit suite still green (2424 tests).
- [ ] Integration tests against a live Zendesk tenant exercise list and get.

🤖 Generated with [Claude Code](https://claude.com/claude-code)