### PR TITLE
feat(ticketing): add side conversations endpoints

### DIFF
--- a/libzapi/application/commands/ticketing/side_conversation_cmds.py
+++ b/libzapi/application/commands/ticketing/side_conversation_cmds.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass(frozen=True, slots=True)
+class SideConversationMessageCmd:
+    body: str
+    subject: Optional[str] = None
+    to: List[dict] = field(default_factory=list)
+    from_: Optional[dict] = None
+    body_html: Optional[str] = None
+    attachment_ids: List[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class CreateSideConversationCmd:
+    message: SideConversationMessageCmd
+    external_ids: Optional[dict] = None
+
+
+@dataclass(frozen=True, slots=True)
+class ReplySideConversationCmd:
+    message: SideConversationMessageCmd
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateSideConversationCmd:
+    state: Optional[str] = None

--- a/libzapi/application/services/ticketing/__init__.py
+++ b/libzapi/application/services/ticketing/__init__.py
@@ -19,6 +19,9 @@ from libzapi.application.services.ticketing.requests_service import RequestsServ
 from libzapi.application.services.ticketing.schedule_service import ScheduleService
 from libzapi.application.services.ticketing.search_service import SearchService
 from libzapi.application.services.ticketing.sessions_service import SessionsService
+from libzapi.application.services.ticketing.side_conversations_service import (
+    SideConversationsService,
+)
 from libzapi.application.services.ticketing.sla_policies_service import SlaPoliciesService
 from libzapi.application.services.ticketing.support_addresses_service import SupportAddressesService
 from libzapi.application.services.ticketing.suspended_tickets_service import SuspendedTicketsService
@@ -72,6 +75,7 @@ class Ticketing:
         self.schedules = ScheduleService(api.ScheduleApiClient(http))
         self.search = SearchService(api.SearchApiClient(http))
         self.sessions = SessionsService(api.SessionApiClient(http))
+        self.side_conversations = SideConversationsService(api.SideConversationApiClient(http))
         self.sla_policies = SlaPoliciesService(api.SlaPolicyApiClient(http))
         self.support_addresses = SupportAddressesService(api.SupportAddressApiClient(http))
         self.suspended_tickets = SuspendedTicketsService(api.SuspendedTicketApiClient(http))

--- a/libzapi/application/services/ticketing/side_conversations_service.py
+++ b/libzapi/application/services/ticketing/side_conversations_service.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import Iterator, List, Optional
+
+from libzapi.application.commands.ticketing.side_conversation_cmds import (
+    CreateSideConversationCmd,
+    ReplySideConversationCmd,
+    SideConversationMessageCmd,
+    UpdateSideConversationCmd,
+)
+from libzapi.domain.models.ticketing.side_conversation import SideConversation
+from libzapi.infrastructure.api_clients.ticketing.side_conversation_api_client import (
+    SideConversationApiClient,
+)
+
+
+class SideConversationsService:
+    def __init__(self, client: SideConversationApiClient) -> None:
+        self._client = client
+
+    def list_for_ticket(self, ticket_id: int) -> Iterator[SideConversation]:
+        return self._client.list(ticket_id=ticket_id)
+
+    def get(self, ticket_id: int, side_conversation_id: str) -> SideConversation:
+        return self._client.get(
+            ticket_id=ticket_id, side_conversation_id=side_conversation_id
+        )
+
+    def create(
+        self,
+        ticket_id: int,
+        *,
+        body: str,
+        subject: Optional[str] = None,
+        to: Optional[List[dict]] = None,
+        from_: Optional[dict] = None,
+        body_html: Optional[str] = None,
+        attachment_ids: Optional[List[str]] = None,
+        external_ids: Optional[dict] = None,
+    ) -> SideConversation:
+        message = SideConversationMessageCmd(
+            body=body,
+            subject=subject,
+            to=list(to) if to else [],
+            from_=from_,
+            body_html=body_html,
+            attachment_ids=list(attachment_ids) if attachment_ids else [],
+        )
+        cmd = CreateSideConversationCmd(message=message, external_ids=external_ids)
+        return self._client.create(ticket_id=ticket_id, entity=cmd)
+
+    def reply(
+        self,
+        ticket_id: int,
+        side_conversation_id: str,
+        *,
+        body: str,
+        body_html: Optional[str] = None,
+        attachment_ids: Optional[List[str]] = None,
+    ) -> SideConversation:
+        message = SideConversationMessageCmd(
+            body=body,
+            body_html=body_html,
+            attachment_ids=list(attachment_ids) if attachment_ids else [],
+        )
+        cmd = ReplySideConversationCmd(message=message)
+        return self._client.reply(
+            ticket_id=ticket_id,
+            side_conversation_id=side_conversation_id,
+            entity=cmd,
+        )
+
+    def update(
+        self,
+        ticket_id: int,
+        side_conversation_id: str,
+        *,
+        state: Optional[str] = None,
+    ) -> SideConversation:
+        cmd = UpdateSideConversationCmd(state=state)
+        return self._client.update(
+            ticket_id=ticket_id,
+            side_conversation_id=side_conversation_id,
+            entity=cmd,
+        )
+
+    def close(self, ticket_id: int, side_conversation_id: str) -> SideConversation:
+        return self.update(
+            ticket_id=ticket_id,
+            side_conversation_id=side_conversation_id,
+            state="closed",
+        )
+
+    def list_events(
+        self, ticket_id: int, side_conversation_id: str
+    ) -> Iterator[dict]:
+        return self._client.list_events(
+            ticket_id=ticket_id, side_conversation_id=side_conversation_id
+        )

--- a/libzapi/domain/models/ticketing/side_conversation.py
+++ b/libzapi/domain/models/ticketing/side_conversation.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional
+
+from libzapi.domain.shared_objects.logical_key import LogicalKey
+
+
+@dataclass(frozen=True, slots=True)
+class SideConversation:
+    id: str
+    ticket_id: int
+    url: Optional[str] = None
+    subject: Optional[str] = None
+    preview_text: Optional[str] = None
+    state: Optional[str] = None
+    participants: List[dict] = field(default_factory=list)
+    message_added_at: Optional[datetime] = None
+    state_updated_at: Optional[datetime] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+    external_ids: Optional[dict] = None
+
+    @property
+    def logical_key(self) -> LogicalKey:
+        return LogicalKey("side_conversation", f"side_conversation_id_{self.id}")

--- a/libzapi/infrastructure/api_clients/ticketing/__init__.py
+++ b/libzapi/infrastructure/api_clients/ticketing/__init__.py
@@ -18,6 +18,9 @@ from libzapi.infrastructure.api_clients.ticketing.request_api_client import Requ
 from libzapi.infrastructure.api_clients.ticketing.schedule_api_client import ScheduleApiClient
 from libzapi.infrastructure.api_clients.ticketing.search_api_client import SearchApiClient
 from libzapi.infrastructure.api_clients.ticketing.session_api_client import SessionApiClient
+from libzapi.infrastructure.api_clients.ticketing.side_conversation_api_client import (
+    SideConversationApiClient,
+)
 from libzapi.infrastructure.api_clients.ticketing.sla_policy_api_client import SlaPolicyApiClient
 from libzapi.infrastructure.api_clients.ticketing.suspended_ticket_api_client import SuspendedTicketApiClient
 from libzapi.infrastructure.api_clients.ticketing.support_address_api_client import SupportAddressApiClient
@@ -56,6 +59,7 @@ __all__ = [
     "ScheduleApiClient",
     "SearchApiClient",
     "SessionApiClient",
+    "SideConversationApiClient",
     "SlaPolicyApiClient",
     "SupportAddressApiClient",
     "SuspendedTicketApiClient",

--- a/libzapi/infrastructure/api_clients/ticketing/side_conversation_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/side_conversation_api_client.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+from libzapi.application.commands.ticketing.side_conversation_cmds import (
+    CreateSideConversationCmd,
+    ReplySideConversationCmd,
+    UpdateSideConversationCmd,
+)
+from libzapi.domain.models.ticketing.side_conversation import SideConversation
+from libzapi.infrastructure.http.client import HttpClient
+from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.mappers.ticketing.side_conversation_mapper import (
+    to_payload_create,
+    to_payload_reply,
+    to_payload_update,
+)
+from libzapi.infrastructure.serialization.parse import to_domain
+
+
+class SideConversationApiClient:
+    """HTTP adapter for Zendesk Side Conversations."""
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def list(self, ticket_id: int) -> Iterator[SideConversation]:
+        path = f"/api/v2/tickets/{int(ticket_id)}/side_conversations"
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path=path,
+            base_url=self._http.base_url,
+            items_key="side_conversations",
+        ):
+            yield to_domain(data=obj, cls=SideConversation)
+
+    def get(self, ticket_id: int, side_conversation_id: str) -> SideConversation:
+        data = self._http.get(
+            f"/api/v2/tickets/{int(ticket_id)}/side_conversations/{side_conversation_id}"
+        )
+        return to_domain(data=data["side_conversation"], cls=SideConversation)
+
+    def create(
+        self, ticket_id: int, entity: CreateSideConversationCmd
+    ) -> SideConversation:
+        data = self._http.post(
+            f"/api/v2/tickets/{int(ticket_id)}/side_conversations",
+            to_payload_create(entity),
+        )
+        return to_domain(data=data["side_conversation"], cls=SideConversation)
+
+    def reply(
+        self,
+        ticket_id: int,
+        side_conversation_id: str,
+        entity: ReplySideConversationCmd,
+    ) -> SideConversation:
+        data = self._http.post(
+            f"/api/v2/tickets/{int(ticket_id)}/side_conversations/{side_conversation_id}/reply",
+            to_payload_reply(entity),
+        )
+        return to_domain(data=data["side_conversation"], cls=SideConversation)
+
+    def update(
+        self,
+        ticket_id: int,
+        side_conversation_id: str,
+        entity: UpdateSideConversationCmd,
+    ) -> SideConversation:
+        data = self._http.put(
+            f"/api/v2/tickets/{int(ticket_id)}/side_conversations/{side_conversation_id}",
+            to_payload_update(entity),
+        )
+        return to_domain(data=data["side_conversation"], cls=SideConversation)
+
+    def list_events(
+        self, ticket_id: int, side_conversation_id: str
+    ) -> Iterator[dict]:
+        path = (
+            f"/api/v2/tickets/{int(ticket_id)}/side_conversations/"
+            f"{side_conversation_id}/events"
+        )
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path=path,
+            base_url=self._http.base_url,
+            items_key="events",
+        ):
+            yield obj

--- a/libzapi/infrastructure/mappers/ticketing/side_conversation_mapper.py
+++ b/libzapi/infrastructure/mappers/ticketing/side_conversation_mapper.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from libzapi.application.commands.ticketing.side_conversation_cmds import (
+    CreateSideConversationCmd,
+    ReplySideConversationCmd,
+    SideConversationMessageCmd,
+    UpdateSideConversationCmd,
+)
+
+
+def _message_to_payload(msg: SideConversationMessageCmd) -> dict:
+    payload: dict = {"body": msg.body}
+    if msg.subject is not None:
+        payload["subject"] = msg.subject
+    if msg.to:
+        payload["to"] = list(msg.to)
+    if msg.from_ is not None:
+        payload["from"] = msg.from_
+    if msg.body_html is not None:
+        payload["body_html"] = msg.body_html
+    if msg.attachment_ids:
+        payload["attachment_ids"] = list(msg.attachment_ids)
+    return payload
+
+
+def to_payload_create(cmd: CreateSideConversationCmd) -> dict:
+    payload: dict = {"message": _message_to_payload(cmd.message)}
+    if cmd.external_ids is not None:
+        payload["external_ids"] = cmd.external_ids
+    return {"side_conversation": payload}
+
+
+def to_payload_reply(cmd: ReplySideConversationCmd) -> dict:
+    return {"message": _message_to_payload(cmd.message)}
+
+
+def to_payload_update(cmd: UpdateSideConversationCmd) -> dict:
+    inner: dict = {}
+    if cmd.state is not None:
+        inner["state"] = cmd.state
+    return {"side_conversation": inner}

--- a/tests/integration/ticketing/test_side_conversations.py
+++ b/tests/integration/ticketing/test_side_conversations.py
@@ -1,0 +1,17 @@
+import itertools
+
+import pytest
+
+from libzapi import Ticketing
+
+
+def test_list_for_ticket_returns_iterable(ticketing: Ticketing):
+    tickets = list(itertools.islice(ticketing.tickets.list(), 1))
+    if not tickets:
+        pytest.skip("No tickets on this tenant.")
+    items = list(
+        itertools.islice(
+            ticketing.side_conversations.list_for_ticket(tickets[0].id), 20
+        )
+    )
+    assert isinstance(items, list)

--- a/tests/unit/ticketing/test_side_conversation.py
+++ b/tests/unit/ticketing/test_side_conversation.py
@@ -1,0 +1,125 @@
+import pytest
+
+from libzapi.application.commands.ticketing.side_conversation_cmds import (
+    CreateSideConversationCmd,
+    ReplySideConversationCmd,
+    SideConversationMessageCmd,
+    UpdateSideConversationCmd,
+)
+from libzapi.domain.errors import NotFound, RateLimited, Unauthorized, UnprocessableEntity
+from libzapi.infrastructure.api_clients.ticketing import SideConversationApiClient
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.side_conversation_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+def test_list_hits_expected_path(http, domain):
+    http.get.return_value = {"side_conversations": [{"id": "abc"}]}
+    client = SideConversationApiClient(http)
+    items = list(client.list(42))
+    assert len(items) == 1
+    assert items[0]["_cls"] == "SideConversation"
+    http.get.assert_called_with("/api/v2/tickets/42/side_conversations")
+
+
+def test_list_yields_items(http, domain):
+    http.get.return_value = {
+        "side_conversations": [{"id": "a"}, {"id": "b"}],
+        "meta": {"has_more": False},
+        "links": {"next": None},
+    }
+    client = SideConversationApiClient(http)
+    items = list(client.list(7))
+    assert len(items) == 2
+    assert all(i["_cls"] == "SideConversation" for i in items)
+
+
+def test_list_coerces_ticket_id(http, domain):
+    http.get.return_value = {"side_conversations": []}
+    client = SideConversationApiClient(http)
+    list(client.list(ticket_id="5"))  # type: ignore[arg-type]
+    http.get.assert_called_with("/api/v2/tickets/5/side_conversations")
+
+
+def test_get_returns_domain(http, domain):
+    http.get.return_value = {"side_conversation": {"id": "abc"}}
+    client = SideConversationApiClient(http)
+    result = client.get(42, "abc")
+    assert result["_cls"] == "SideConversation"
+    http.get.assert_called_with("/api/v2/tickets/42/side_conversations/abc")
+
+
+def test_create_posts_payload(http, domain):
+    http.post.return_value = {"side_conversation": {"id": "new"}}
+    client = SideConversationApiClient(http)
+    cmd = CreateSideConversationCmd(
+        message=SideConversationMessageCmd(body="hi", subject="Q")
+    )
+    client.create(ticket_id=42, entity=cmd)
+    http.post.assert_called_with(
+        "/api/v2/tickets/42/side_conversations",
+        {"side_conversation": {"message": {"body": "hi", "subject": "Q"}}},
+    )
+
+
+def test_reply_posts_payload(http, domain):
+    http.post.return_value = {"side_conversation": {"id": "abc"}}
+    client = SideConversationApiClient(http)
+    cmd = ReplySideConversationCmd(message=SideConversationMessageCmd(body="r"))
+    client.reply(ticket_id=42, side_conversation_id="abc", entity=cmd)
+    http.post.assert_called_with(
+        "/api/v2/tickets/42/side_conversations/abc/reply",
+        {"message": {"body": "r"}},
+    )
+
+
+def test_update_puts_payload(http, domain):
+    http.put.return_value = {"side_conversation": {"id": "abc"}}
+    client = SideConversationApiClient(http)
+    cmd = UpdateSideConversationCmd(state="closed")
+    client.update(ticket_id=42, side_conversation_id="abc", entity=cmd)
+    http.put.assert_called_with(
+        "/api/v2/tickets/42/side_conversations/abc",
+        {"side_conversation": {"state": "closed"}},
+    )
+
+
+def test_list_events_yields_dicts(http, domain):
+    http.get.return_value = {
+        "events": [{"id": "e1"}, {"id": "e2"}],
+        "meta": {"has_more": False},
+        "links": {"next": None},
+    }
+    client = SideConversationApiClient(http)
+    events = list(client.list_events(42, "abc"))
+    assert events == [{"id": "e1"}, {"id": "e2"}]
+    http.get.assert_called_with("/api/v2/tickets/42/side_conversations/abc/events")
+
+
+@pytest.mark.parametrize(
+    "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+)
+def test_raises_on_http_error(error_cls, http):
+    http.get.side_effect = error_cls("error")
+    client = SideConversationApiClient(http)
+    with pytest.raises(error_cls):
+        list(client.list(42))
+
+
+def test_side_conversation_logical_key():
+    from libzapi.domain.models.ticketing.side_conversation import SideConversation
+
+    sc = SideConversation(id="abc-123", ticket_id=42)
+    assert sc.logical_key.as_str() == "side_conversation:side_conversation_id_abc-123"

--- a/tests/unit/ticketing/test_side_conversation_mapper.py
+++ b/tests/unit/ticketing/test_side_conversation_mapper.py
@@ -1,0 +1,85 @@
+from libzapi.application.commands.ticketing.side_conversation_cmds import (
+    CreateSideConversationCmd,
+    ReplySideConversationCmd,
+    SideConversationMessageCmd,
+    UpdateSideConversationCmd,
+)
+from libzapi.infrastructure.mappers.ticketing.side_conversation_mapper import (
+    to_payload_create,
+    to_payload_reply,
+    to_payload_update,
+)
+
+
+def test_create_minimal():
+    payload = to_payload_create(
+        CreateSideConversationCmd(
+            message=SideConversationMessageCmd(body="hello"),
+        )
+    )
+    assert payload == {"side_conversation": {"message": {"body": "hello"}}}
+
+
+def test_create_with_subject_and_to():
+    payload = to_payload_create(
+        CreateSideConversationCmd(
+            message=SideConversationMessageCmd(
+                body="hi",
+                subject="Question",
+                to=[{"email": "x@example.com"}],
+                from_={"support_address_id": 1},
+                body_html="<p>hi</p>",
+                attachment_ids=["a1", "a2"],
+            ),
+            external_ids={"foo": "bar"},
+        )
+    )
+    assert payload == {
+        "side_conversation": {
+            "message": {
+                "body": "hi",
+                "subject": "Question",
+                "to": [{"email": "x@example.com"}],
+                "from": {"support_address_id": 1},
+                "body_html": "<p>hi</p>",
+                "attachment_ids": ["a1", "a2"],
+            },
+            "external_ids": {"foo": "bar"},
+        }
+    }
+
+
+def test_reply_minimal():
+    payload = to_payload_reply(
+        ReplySideConversationCmd(message=SideConversationMessageCmd(body="reply"))
+    )
+    assert payload == {"message": {"body": "reply"}}
+
+
+def test_reply_with_attachments():
+    payload = to_payload_reply(
+        ReplySideConversationCmd(
+            message=SideConversationMessageCmd(
+                body="r",
+                body_html="<p>r</p>",
+                attachment_ids=["a1"],
+            )
+        )
+    )
+    assert payload == {
+        "message": {
+            "body": "r",
+            "body_html": "<p>r</p>",
+            "attachment_ids": ["a1"],
+        }
+    }
+
+
+def test_update_empty():
+    payload = to_payload_update(UpdateSideConversationCmd())
+    assert payload == {"side_conversation": {}}
+
+
+def test_update_with_state():
+    payload = to_payload_update(UpdateSideConversationCmd(state="closed"))
+    assert payload == {"side_conversation": {"state": "closed"}}

--- a/tests/unit/ticketing/test_side_conversations_service.py
+++ b/tests/unit/ticketing/test_side_conversations_service.py
@@ -1,0 +1,127 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.commands.ticketing.side_conversation_cmds import (
+    CreateSideConversationCmd,
+    ReplySideConversationCmd,
+    UpdateSideConversationCmd,
+)
+from libzapi.application.services.ticketing.side_conversations_service import (
+    SideConversationsService,
+)
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return SideConversationsService(client), client
+
+
+class TestDelegation:
+    def test_list_for_ticket_delegates(self):
+        service, client = _make_service()
+        client.list.return_value = sentinel.items
+        assert service.list_for_ticket(42) is sentinel.items
+        client.list.assert_called_once_with(ticket_id=42)
+
+    def test_get_delegates(self):
+        service, client = _make_service()
+        client.get.return_value = sentinel.sc
+        assert service.get(42, "abc") is sentinel.sc
+        client.get.assert_called_once_with(ticket_id=42, side_conversation_id="abc")
+
+    def test_list_events_delegates(self):
+        service, client = _make_service()
+        client.list_events.return_value = sentinel.events
+        assert service.list_events(42, "abc") is sentinel.events
+        client.list_events.assert_called_once_with(
+            ticket_id=42, side_conversation_id="abc"
+        )
+
+
+class TestCreate:
+    def test_builds_minimal_cmd(self):
+        service, client = _make_service()
+        client.create.return_value = sentinel.sc
+        result = service.create(ticket_id=42, body="hello")
+        call = client.create.call_args
+        assert call.kwargs["ticket_id"] == 42
+        cmd = call.kwargs["entity"]
+        assert isinstance(cmd, CreateSideConversationCmd)
+        assert cmd.message.body == "hello"
+        assert cmd.message.to == []
+        assert cmd.external_ids is None
+        assert result is sentinel.sc
+
+    def test_builds_full_cmd(self):
+        service, client = _make_service()
+        service.create(
+            ticket_id=42,
+            body="b",
+            subject="s",
+            to=[{"email": "x@example.com"}],
+            from_={"support_address_id": 1},
+            body_html="<p>b</p>",
+            attachment_ids=["a1"],
+            external_ids={"k": "v"},
+        )
+        cmd = client.create.call_args.kwargs["entity"]
+        assert cmd.message.subject == "s"
+        assert cmd.message.to == [{"email": "x@example.com"}]
+        assert cmd.message.from_ == {"support_address_id": 1}
+        assert cmd.message.body_html == "<p>b</p>"
+        assert cmd.message.attachment_ids == ["a1"]
+        assert cmd.external_ids == {"k": "v"}
+
+
+class TestReply:
+    def test_builds_cmd_and_delegates(self):
+        service, client = _make_service()
+        client.reply.return_value = sentinel.sc
+        result = service.reply(
+            ticket_id=42,
+            side_conversation_id="abc",
+            body="r",
+            body_html="<p>r</p>",
+            attachment_ids=["a1"],
+        )
+        call = client.reply.call_args
+        assert call.kwargs["ticket_id"] == 42
+        assert call.kwargs["side_conversation_id"] == "abc"
+        cmd = call.kwargs["entity"]
+        assert isinstance(cmd, ReplySideConversationCmd)
+        assert cmd.message.body == "r"
+        assert cmd.message.body_html == "<p>r</p>"
+        assert cmd.message.attachment_ids == ["a1"]
+        assert result is sentinel.sc
+
+
+class TestUpdate:
+    def test_update_delegates(self):
+        service, client = _make_service()
+        service.update(ticket_id=42, side_conversation_id="abc", state="closed")
+        cmd = client.update.call_args.kwargs["entity"]
+        assert isinstance(cmd, UpdateSideConversationCmd)
+        assert cmd.state == "closed"
+
+    def test_close_sets_state_closed(self):
+        service, client = _make_service()
+        service.close(ticket_id=42, side_conversation_id="abc")
+        cmd = client.update.call_args.kwargs["entity"]
+        assert cmd.state == "closed"
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.list.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list_for_ticket(42)
+
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_create_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.create.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.create(ticket_id=1, body="x")


### PR DESCRIPTION
## Summary
- Add `SideConversation` domain model, `CreateSideConversationCmd` / `ReplySideConversationCmd` / `UpdateSideConversationCmd`, mapper, and `SideConversationApiClient` (`list`, `get`, `create`, `reply`, `update`, `list_events`).
- Add `SideConversationsService` (with `close(...)` convenience) and wire it into the `Ticketing` facade as `ticketing.side_conversations`.
- 100% unit coverage.

Part of #79 (Batch 2 — final).

## Test plan
- [x] Unit: `test_side_conversation.py`, `test_side_conversation_mapper.py`, `test_side_conversations_service.py` — 31 passed, 100% coverage
- [x] Full unit suite — 2458 passed
- [ ] Integration smoke on a live tenant via `tests/integration/ticketing/test_side_conversations.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)