### PR TITLE
feat(ticketing): add organization fields endpoints

### DIFF
--- a/libzapi/application/commands/ticketing/organization_field_cmds.py
+++ b/libzapi/application/commands/ticketing/organization_field_cmds.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, TypeAlias
+
+
+@dataclass(frozen=True, slots=True)
+class CreateOrganizationFieldCmd:
+    key: str
+    type: str
+    title: str
+    description: str | None = None
+    active: bool | None = None
+    position: int | None = None
+    regexp_for_validation: str | None = None
+    tag: str | None = None
+    custom_field_options: Iterable[dict[str, Any]] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class UpdateOrganizationFieldCmd:
+    key: str | None = None
+    title: str | None = None
+    description: str | None = None
+    active: bool | None = None
+    position: int | None = None
+    regexp_for_validation: str | None = None
+    tag: str | None = None
+    custom_field_options: Iterable[dict[str, Any]] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class OrganizationFieldOptionCmd:
+    name: str
+    value: str
+    id: int | None = None
+
+
+OrganizationFieldCmd: TypeAlias = (
+    CreateOrganizationFieldCmd | UpdateOrganizationFieldCmd
+)

--- a/libzapi/application/services/ticketing/__init__.py
+++ b/libzapi/application/services/ticketing/__init__.py
@@ -12,6 +12,9 @@ from libzapi.application.services.ticketing.group_memberships_service import (
 from libzapi.application.services.ticketing.job_statuses_service import JobStatusesService
 from libzapi.application.services.ticketing.macro_service import MacroService
 from libzapi.application.services.ticketing.organizations_service import OrganizationsService
+from libzapi.application.services.ticketing.organization_fields_service import (
+    OrganizationFieldsService,
+)
 from libzapi.application.services.ticketing.organization_memberships_service import (
     OrganizationMembershipsService,
 )
@@ -65,6 +68,9 @@ class Ticketing:
         self.job_statuses = JobStatusesService(api.JobStatusApiClient(http))
         self.macros = MacroService(api.MacroApiClient(http))
         self.organizations = OrganizationsService(api.OrganizationApiClient(http))
+        self.organization_fields = OrganizationFieldsService(
+            api.OrganizationFieldApiClient(http)
+        )
         self.organization_memberships = OrganizationMembershipsService(
             api.OrganizationMembershipApiClient(http)
         )

--- a/libzapi/application/services/ticketing/organization_fields_service.py
+++ b/libzapi/application/services/ticketing/organization_fields_service.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from libzapi.application.commands.ticketing.organization_field_cmds import (
+    CreateOrganizationFieldCmd,
+    OrganizationFieldOptionCmd,
+    UpdateOrganizationFieldCmd,
+)
+from libzapi.domain.models.ticketing.organization_field import (
+    OrganizationField,
+    OrganizationFieldOption,
+)
+from libzapi.infrastructure.api_clients.ticketing.organization_field_api_client import (
+    OrganizationFieldApiClient,
+)
+
+
+class OrganizationFieldsService:
+    def __init__(self, client: OrganizationFieldApiClient) -> None:
+        self._client = client
+
+    def list_all(self) -> Iterable[OrganizationField]:
+        return self._client.list_all()
+
+    def get_by_id(self, organization_field_id: int) -> OrganizationField:
+        return self._client.get(organization_field_id=organization_field_id)
+
+    def create(self, **fields) -> OrganizationField:
+        return self._client.create(entity=CreateOrganizationFieldCmd(**fields))
+
+    def update(
+        self, organization_field_id: int, **fields
+    ) -> OrganizationField:
+        return self._client.update(
+            organization_field_id=organization_field_id,
+            entity=UpdateOrganizationFieldCmd(**fields),
+        )
+
+    def delete(self, organization_field_id: int) -> None:
+        self._client.delete(organization_field_id=organization_field_id)
+
+    def reorder(self, organization_field_ids: Iterable[int]) -> None:
+        self._client.reorder(organization_field_ids=organization_field_ids)
+
+    def list_options(
+        self, organization_field_id: int
+    ) -> Iterable[OrganizationFieldOption]:
+        return self._client.list_options(
+            organization_field_id=organization_field_id
+        )
+
+    def get_option_by_id(
+        self, organization_field_id: int, option_id: int
+    ) -> OrganizationFieldOption:
+        return self._client.get_option(
+            organization_field_id=organization_field_id, option_id=option_id
+        )
+
+    def upsert_option(
+        self,
+        organization_field_id: int,
+        name: str,
+        value: str,
+        id: int | None = None,
+    ) -> OrganizationFieldOption:
+        return self._client.upsert_option(
+            organization_field_id=organization_field_id,
+            option=OrganizationFieldOptionCmd(name=name, value=value, id=id),
+        )
+
+    def delete_option(
+        self, organization_field_id: int, option_id: int
+    ) -> None:
+        self._client.delete_option(
+            organization_field_id=organization_field_id, option_id=option_id
+        )

--- a/libzapi/domain/models/ticketing/organization_field.py
+++ b/libzapi/domain/models/ticketing/organization_field.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Optional
+
+from libzapi.domain.shared_objects.logical_key import LogicalKey
+
+
+@dataclass(frozen=True, slots=True)
+class OrganizationFieldOption:
+    id: int
+    name: str
+    raw_name: str
+    value: str
+    position: Optional[int] = None
+
+
+@dataclass(frozen=True, slots=True)
+class OrganizationField:
+    id: int
+    url: str
+    type: str
+    key: str
+    title: str
+    description: str
+    raw_description: str
+    position: int
+    active: bool
+    system: bool
+    regexp_for_validation: Optional[str]
+    created_at: datetime | None
+    updated_at: datetime | None
+    tag: Optional[str] = None
+    custom_field_options: Optional[list[OrganizationFieldOption]] = field(
+        default_factory=list
+    )
+
+    @property
+    def logical_key(self) -> LogicalKey:
+        base = self.key.lower().replace(" ", "_")
+        return LogicalKey("organization_field", base)

--- a/libzapi/infrastructure/api_clients/ticketing/__init__.py
+++ b/libzapi/infrastructure/api_clients/ticketing/__init__.py
@@ -11,6 +11,9 @@ from libzapi.infrastructure.api_clients.ticketing.group_membership_api_client im
 from libzapi.infrastructure.api_clients.ticketing.job_status_api_client import JobStatusApiClient
 from libzapi.infrastructure.api_clients.ticketing.macro_api_client import MacroApiClient
 from libzapi.infrastructure.api_clients.ticketing.organization_api_client import OrganizationApiClient
+from libzapi.infrastructure.api_clients.ticketing.organization_field_api_client import (
+    OrganizationFieldApiClient,
+)
 from libzapi.infrastructure.api_clients.ticketing.organization_membership_api_client import (
     OrganizationMembershipApiClient,
 )
@@ -51,6 +54,7 @@ __all__ = [
     "JobStatusApiClient",
     "MacroApiClient",
     "OrganizationApiClient",
+    "OrganizationFieldApiClient",
     "OrganizationMembershipApiClient",
     "RequestApiClient",
     "ScheduleApiClient",

--- a/libzapi/infrastructure/api_clients/ticketing/organization_field_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/organization_field_api_client.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+from libzapi.application.commands.ticketing.organization_field_cmds import (
+    CreateOrganizationFieldCmd,
+    OrganizationFieldOptionCmd,
+    UpdateOrganizationFieldCmd,
+)
+from libzapi.domain.models.ticketing.organization_field import (
+    OrganizationField,
+    OrganizationFieldOption,
+)
+from libzapi.infrastructure.http.client import HttpClient
+from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.mappers.ticketing.organization_field_mapper import (
+    option_to_payload,
+    to_payload_create,
+    to_payload_update,
+)
+from libzapi.infrastructure.serialization.parse import to_domain
+
+
+class OrganizationFieldApiClient:
+    """HTTP adapter for Zendesk Organization Fields."""
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def list_all(self) -> Iterator[OrganizationField]:
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path="/api/v2/organization_fields",
+            base_url=self._http.base_url,
+            items_key="organization_fields",
+        ):
+            yield to_domain(data=obj, cls=OrganizationField)
+
+    def get(self, organization_field_id: int) -> OrganizationField:
+        data = self._http.get(
+            f"/api/v2/organization_fields/{int(organization_field_id)}"
+        )
+        return to_domain(data=data["organization_field"], cls=OrganizationField)
+
+    def create(self, entity: CreateOrganizationFieldCmd) -> OrganizationField:
+        data = self._http.post(
+            "/api/v2/organization_fields", to_payload_create(entity)
+        )
+        return to_domain(data=data["organization_field"], cls=OrganizationField)
+
+    def update(
+        self,
+        organization_field_id: int,
+        entity: UpdateOrganizationFieldCmd,
+    ) -> OrganizationField:
+        data = self._http.put(
+            f"/api/v2/organization_fields/{int(organization_field_id)}",
+            to_payload_update(entity),
+        )
+        return to_domain(data=data["organization_field"], cls=OrganizationField)
+
+    def delete(self, organization_field_id: int) -> None:
+        self._http.delete(
+            f"/api/v2/organization_fields/{int(organization_field_id)}"
+        )
+
+    def reorder(self, organization_field_ids: Iterable[int]) -> None:
+        payload = {"organization_field_ids": [int(i) for i in organization_field_ids]}
+        self._http.put("/api/v2/organization_fields/reorder", payload)
+
+    def list_options(
+        self, organization_field_id: int
+    ) -> Iterator[OrganizationFieldOption]:
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path=f"/api/v2/organization_fields/{int(organization_field_id)}/options",
+            base_url=self._http.base_url,
+            items_key="custom_field_options",
+        ):
+            yield to_domain(data=obj, cls=OrganizationFieldOption)
+
+    def get_option(
+        self, organization_field_id: int, option_id: int
+    ) -> OrganizationFieldOption:
+        data = self._http.get(
+            f"/api/v2/organization_fields/{int(organization_field_id)}/options/{int(option_id)}"
+        )
+        return to_domain(
+            data=data["custom_field_option"], cls=OrganizationFieldOption
+        )
+
+    def upsert_option(
+        self,
+        organization_field_id: int,
+        option: OrganizationFieldOptionCmd,
+    ) -> OrganizationFieldOption:
+        data = self._http.post(
+            f"/api/v2/organization_fields/{int(organization_field_id)}/options",
+            option_to_payload(option),
+        )
+        return to_domain(
+            data=data["custom_field_option"], cls=OrganizationFieldOption
+        )
+
+    def delete_option(
+        self, organization_field_id: int, option_id: int
+    ) -> None:
+        self._http.delete(
+            f"/api/v2/organization_fields/{int(organization_field_id)}/options/{int(option_id)}"
+        )

--- a/libzapi/infrastructure/mappers/ticketing/organization_field_mapper.py
+++ b/libzapi/infrastructure/mappers/ticketing/organization_field_mapper.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from libzapi.application.commands.ticketing.organization_field_cmds import (
+    CreateOrganizationFieldCmd,
+    OrganizationFieldOptionCmd,
+    UpdateOrganizationFieldCmd,
+)
+
+
+def _add_optionals(
+    body: dict, cmd: CreateOrganizationFieldCmd | UpdateOrganizationFieldCmd
+) -> None:
+    if cmd.description is not None:
+        body["description"] = cmd.description
+    if cmd.active is not None:
+        body["active"] = cmd.active
+    if cmd.position is not None:
+        body["position"] = cmd.position
+    if cmd.regexp_for_validation is not None:
+        body["regexp_for_validation"] = cmd.regexp_for_validation
+    if cmd.tag is not None:
+        body["tag"] = cmd.tag
+    if cmd.custom_field_options is not None:
+        body["custom_field_options"] = list(cmd.custom_field_options)
+
+
+def to_payload_create(cmd: CreateOrganizationFieldCmd) -> dict:
+    body: dict = {"key": cmd.key, "type": cmd.type, "title": cmd.title}
+    _add_optionals(body, cmd)
+    return {"organization_field": body}
+
+
+def to_payload_update(cmd: UpdateOrganizationFieldCmd) -> dict:
+    body: dict = {}
+    if cmd.key is not None:
+        body["key"] = cmd.key
+    if cmd.title is not None:
+        body["title"] = cmd.title
+    _add_optionals(body, cmd)
+    return {"organization_field": body}
+
+
+def option_to_payload(cmd: OrganizationFieldOptionCmd) -> dict:
+    body: dict = {"name": cmd.name, "value": cmd.value}
+    if cmd.id is not None:
+        body["id"] = cmd.id
+    return {"custom_field_option": body}

--- a/tests/integration/ticketing/test_organization_fields.py
+++ b/tests/integration/ticketing/test_organization_fields.py
@@ -1,0 +1,17 @@
+import itertools
+
+import pytest
+
+from libzapi import Ticketing
+
+
+def test_list_all(ticketing: Ticketing):
+    items = list(itertools.islice(ticketing.organization_fields.list_all(), 20))
+    assert isinstance(items, list)
+
+
+def test_get_unknown_raises(ticketing: Ticketing):
+    from libzapi.domain.errors import NotFound
+
+    with pytest.raises(NotFound):
+        ticketing.organization_fields.get_by_id(999999999)

--- a/tests/unit/ticketing/test_organization_field.py
+++ b/tests/unit/ticketing/test_organization_field.py
@@ -1,0 +1,144 @@
+import pytest
+
+from libzapi.application.commands.ticketing.organization_field_cmds import (
+    CreateOrganizationFieldCmd,
+    OrganizationFieldOptionCmd,
+    UpdateOrganizationFieldCmd,
+)
+from libzapi.domain.errors import NotFound, RateLimited, Unauthorized, UnprocessableEntity
+from libzapi.infrastructure.api_clients.ticketing import OrganizationFieldApiClient
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.organization_field_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+class TestFields:
+    def test_list_all_yields(self, http, domain):
+        http.get.return_value = {
+            "organization_fields": [{"id": 1}, {"id": 2}],
+            "meta": {"has_more": False},
+            "links": {"next": None},
+        }
+        client = OrganizationFieldApiClient(http)
+        items = list(client.list_all())
+        assert len(items) == 2
+        assert all(i["_cls"] == "OrganizationField" for i in items)
+        http.get.assert_called_with("/api/v2/organization_fields")
+
+    def test_get(self, http, domain):
+        http.get.return_value = {"organization_field": {"id": 7}}
+        client = OrganizationFieldApiClient(http)
+        result = client.get(7)
+        assert result["_cls"] == "OrganizationField"
+        http.get.assert_called_with("/api/v2/organization_fields/7")
+
+    def test_create(self, http, domain):
+        http.post.return_value = {"organization_field": {"id": 1}}
+        client = OrganizationFieldApiClient(http)
+        client.create(
+            CreateOrganizationFieldCmd(key="k", type="text", title="t")
+        )
+        http.post.assert_called_with(
+            "/api/v2/organization_fields",
+            {"organization_field": {"key": "k", "type": "text", "title": "t"}},
+        )
+
+    def test_update(self, http, domain):
+        http.put.return_value = {"organization_field": {"id": 7}}
+        client = OrganizationFieldApiClient(http)
+        client.update(7, UpdateOrganizationFieldCmd(title="new"))
+        http.put.assert_called_with(
+            "/api/v2/organization_fields/7",
+            {"organization_field": {"title": "new"}},
+        )
+
+    def test_delete(self, http):
+        client = OrganizationFieldApiClient(http)
+        client.delete(7)
+        http.delete.assert_called_with("/api/v2/organization_fields/7")
+
+    def test_reorder(self, http):
+        client = OrganizationFieldApiClient(http)
+        client.reorder([3, 1, 2])
+        http.put.assert_called_with(
+            "/api/v2/organization_fields/reorder",
+            {"organization_field_ids": [3, 1, 2]},
+        )
+
+
+class TestOptions:
+    def test_list_options(self, http, domain):
+        http.get.return_value = {
+            "custom_field_options": [{"id": 1}],
+            "meta": {"has_more": False},
+            "links": {"next": None},
+        }
+        client = OrganizationFieldApiClient(http)
+        items = list(client.list_options(7))
+        assert len(items) == 1
+        assert items[0]["_cls"] == "OrganizationFieldOption"
+        http.get.assert_called_with("/api/v2/organization_fields/7/options")
+
+    def test_get_option(self, http, domain):
+        http.get.return_value = {"custom_field_option": {"id": 9}}
+        client = OrganizationFieldApiClient(http)
+        result = client.get_option(7, 9)
+        assert result["_cls"] == "OrganizationFieldOption"
+        http.get.assert_called_with("/api/v2/organization_fields/7/options/9")
+
+    def test_upsert_option(self, http, domain):
+        http.post.return_value = {"custom_field_option": {"id": 9}}
+        client = OrganizationFieldApiClient(http)
+        client.upsert_option(7, OrganizationFieldOptionCmd(name="A", value="a"))
+        http.post.assert_called_with(
+            "/api/v2/organization_fields/7/options",
+            {"custom_field_option": {"name": "A", "value": "a"}},
+        )
+
+    def test_delete_option(self, http):
+        client = OrganizationFieldApiClient(http)
+        client.delete_option(7, 9)
+        http.delete.assert_called_with("/api/v2/organization_fields/7/options/9")
+
+
+@pytest.mark.parametrize(
+    "error_cls", [Unauthorized, NotFound, UnprocessableEntity, RateLimited]
+)
+def test_raises_on_http_error(error_cls, http):
+    http.get.side_effect = error_cls("error")
+    client = OrganizationFieldApiClient(http)
+    with pytest.raises(error_cls):
+        list(client.list_all())
+
+
+def test_logical_key():
+    from libzapi.domain.models.ticketing.organization_field import OrganizationField
+
+    field = OrganizationField(
+        id=1,
+        url="u",
+        type="text",
+        key="Tier_Of_Account",
+        title="t",
+        description="d",
+        raw_description="rd",
+        position=0,
+        active=True,
+        system=False,
+        regexp_for_validation=None,
+        created_at=None,
+        updated_at=None,
+    )
+    assert field.logical_key.as_str() == "organization_field:tier_of_account"

--- a/tests/unit/ticketing/test_organization_field_mapper.py
+++ b/tests/unit/ticketing/test_organization_field_mapper.py
@@ -1,0 +1,89 @@
+from libzapi.application.commands.ticketing.organization_field_cmds import (
+    CreateOrganizationFieldCmd,
+    OrganizationFieldOptionCmd,
+    UpdateOrganizationFieldCmd,
+)
+from libzapi.infrastructure.mappers.ticketing.organization_field_mapper import (
+    option_to_payload,
+    to_payload_create,
+    to_payload_update,
+)
+
+
+def test_create_minimal():
+    payload = to_payload_create(
+        CreateOrganizationFieldCmd(key="tier", type="text", title="Tier")
+    )
+    assert payload == {
+        "organization_field": {"key": "tier", "type": "text", "title": "Tier"}
+    }
+
+
+def test_create_with_optionals():
+    payload = to_payload_create(
+        CreateOrganizationFieldCmd(
+            key="priority",
+            type="dropdown",
+            title="Priority",
+            description="d",
+            active=True,
+            position=5,
+            regexp_for_validation="^a$",
+            tag="p",
+            custom_field_options=[{"name": "A", "value": "a"}],
+        )
+    )
+    assert payload == {
+        "organization_field": {
+            "key": "priority",
+            "type": "dropdown",
+            "title": "Priority",
+            "description": "d",
+            "active": True,
+            "position": 5,
+            "regexp_for_validation": "^a$",
+            "tag": "p",
+            "custom_field_options": [{"name": "A", "value": "a"}],
+        }
+    }
+
+
+def test_create_preserves_false_active():
+    payload = to_payload_create(
+        CreateOrganizationFieldCmd(
+            key="k", type="text", title="t", active=False
+        )
+    )
+    assert payload["organization_field"]["active"] is False
+
+
+def test_update_empty():
+    assert to_payload_update(UpdateOrganizationFieldCmd()) == {
+        "organization_field": {}
+    }
+
+
+def test_update_with_fields():
+    payload = to_payload_update(
+        UpdateOrganizationFieldCmd(key="k", title="t", position=2, active=False)
+    )
+    assert payload == {
+        "organization_field": {
+            "key": "k",
+            "title": "t",
+            "position": 2,
+            "active": False,
+        }
+    }
+
+
+def test_option_payload_minimal():
+    assert option_to_payload(OrganizationFieldOptionCmd(name="A", value="a")) == {
+        "custom_field_option": {"name": "A", "value": "a"}
+    }
+
+
+def test_option_payload_with_id():
+    assert option_to_payload(
+        OrganizationFieldOptionCmd(name="A", value="a", id=7)
+    ) == {"custom_field_option": {"name": "A", "value": "a", "id": 7}}

--- a/tests/unit/ticketing/test_organization_fields_service.py
+++ b/tests/unit/ticketing/test_organization_fields_service.py
@@ -1,0 +1,108 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.commands.ticketing.organization_field_cmds import (
+    CreateOrganizationFieldCmd,
+    OrganizationFieldOptionCmd,
+    UpdateOrganizationFieldCmd,
+)
+from libzapi.application.services.ticketing.organization_fields_service import (
+    OrganizationFieldsService,
+)
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return OrganizationFieldsService(client), client
+
+
+class TestDelegation:
+    def test_list_all_delegates(self):
+        service, client = _make_service()
+        client.list_all.return_value = sentinel.items
+        assert service.list_all() is sentinel.items
+        client.list_all.assert_called_once_with()
+
+    def test_get_by_id_delegates(self):
+        service, client = _make_service()
+        service.get_by_id(7)
+        client.get.assert_called_once_with(organization_field_id=7)
+
+    def test_delete_delegates(self):
+        service, client = _make_service()
+        service.delete(7)
+        client.delete.assert_called_once_with(organization_field_id=7)
+
+    def test_reorder_delegates(self):
+        service, client = _make_service()
+        service.reorder([1, 2])
+        client.reorder.assert_called_once_with(organization_field_ids=[1, 2])
+
+    def test_list_options_delegates(self):
+        service, client = _make_service()
+        service.list_options(7)
+        client.list_options.assert_called_once_with(organization_field_id=7)
+
+    def test_get_option_by_id_delegates(self):
+        service, client = _make_service()
+        service.get_option_by_id(7, 9)
+        client.get_option.assert_called_once_with(
+            organization_field_id=7, option_id=9
+        )
+
+    def test_delete_option_delegates(self):
+        service, client = _make_service()
+        service.delete_option(7, 9)
+        client.delete_option.assert_called_once_with(
+            organization_field_id=7, option_id=9
+        )
+
+
+class TestCreateUpdate:
+    def test_create_builds_cmd(self):
+        service, client = _make_service()
+        service.create(key="k", type="text", title="t")
+        cmd = client.create.call_args.kwargs["entity"]
+        assert isinstance(cmd, CreateOrganizationFieldCmd)
+        assert cmd.key == "k"
+        assert cmd.type == "text"
+        assert cmd.title == "t"
+
+    def test_update_builds_cmd(self):
+        service, client = _make_service()
+        service.update(7, title="new", position=3)
+        call = client.update.call_args
+        assert call.kwargs["organization_field_id"] == 7
+        cmd = call.kwargs["entity"]
+        assert isinstance(cmd, UpdateOrganizationFieldCmd)
+        assert cmd.title == "new"
+        assert cmd.position == 3
+
+
+class TestUpsertOption:
+    def test_builds_cmd(self):
+        service, client = _make_service()
+        service.upsert_option(7, name="A", value="a")
+        call = client.upsert_option.call_args
+        assert call.kwargs["organization_field_id"] == 7
+        option = call.kwargs["option"]
+        assert isinstance(option, OrganizationFieldOptionCmd)
+        assert option.name == "A"
+        assert option.value == "a"
+        assert option.id is None
+
+    def test_with_id(self):
+        service, client = _make_service()
+        service.upsert_option(7, name="A", value="a", id=9)
+        option = client.upsert_option.call_args.kwargs["option"]
+        assert option.id == 9
+
+
+class TestErrorPropagation:
+    @pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+    def test_list_propagates_error(self, error_cls):
+        service, client = _make_service()
+        client.list_all.side_effect = error_cls("boom")
+        with pytest.raises(error_cls):
+            service.list_all()


### PR DESCRIPTION
## Summary
- Add `OrganizationField` and `OrganizationFieldOption` domain models.
- Add `CreateOrganizationFieldCmd`, `UpdateOrganizationFieldCmd`, and `OrganizationFieldOptionCmd`.
- Add `OrganizationFieldApiClient` with full CRUD (`list_all`, `get`, `create`, `update`, `delete`, `reorder`) and dropdown option endpoints (`list_options`, `get_option`, `upsert_option`, `delete_option`).
- Add `OrganizationFieldsService` and wire it into the `Ticketing` facade as `ticketing.organization_fields`.
- 100% unit coverage.

Part of #79 (Batch 3).

## Test plan
- [x] Unit: `test_organization_field.py`, `test_organization_field_mapper.py`, `test_organization_fields_service.py` — 35 passed, 100% coverage
- [x] Full unit suite — 2462 passed
- [ ] Integration smoke on a live tenant via `tests/integration/ticketing/test_organization_fields.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)