### PR TITLE
feat(ticketing): add locales endpoints

### DIFF
--- a/libzapi/application/services/ticketing/__init__.py
+++ b/libzapi/application/services/ticketing/__init__.py
@@ -10,6 +10,7 @@ from libzapi.application.services.ticketing.group_memberships_service import (
     GroupMembershipsService,
 )
 from libzapi.application.services.ticketing.job_statuses_service import JobStatusesService
+from libzapi.application.services.ticketing.locales_service import LocalesService
 from libzapi.application.services.ticketing.macro_service import MacroService
 from libzapi.application.services.ticketing.organizations_service import OrganizationsService
 from libzapi.application.services.ticketing.organization_memberships_service import (
@@ -63,6 +64,7 @@ class Ticketing:
         self.groups = GroupsService(api.GroupApiClient(http))
         self.group_memberships = GroupMembershipsService(api.GroupMembershipApiClient(http))
         self.job_statuses = JobStatusesService(api.JobStatusApiClient(http))
+        self.locales = LocalesService(api.LocaleApiClient(http))
         self.macros = MacroService(api.MacroApiClient(http))
         self.organizations = OrganizationsService(api.OrganizationApiClient(http))
         self.organization_memberships = OrganizationMembershipsService(

--- a/libzapi/application/services/ticketing/locales_service.py
+++ b/libzapi/application/services/ticketing/locales_service.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+from libzapi.domain.models.ticketing.locale import Locale
+from libzapi.infrastructure.api_clients.ticketing.locale_api_client import (
+    LocaleApiClient,
+)
+
+
+class LocalesService:
+    def __init__(self, client: LocaleApiClient) -> None:
+        self._client = client
+
+    def list_all(self) -> Iterable[Locale]:
+        return self._client.list_all()
+
+    def list_agent(self) -> Iterable[Locale]:
+        return self._client.list_agent()
+
+    def list_public(self) -> Iterable[Locale]:
+        return self._client.list_public()
+
+    def get(self, locale_id_or_code: int | str) -> Locale:
+        return self._client.get(locale_id_or_code=locale_id_or_code)
+
+    def get_current(self) -> Locale:
+        return self._client.get_current()
+
+    def detect_best(self, available: Iterable[str]) -> Locale:
+        return self._client.detect_best(available=available)

--- a/libzapi/domain/models/ticketing/locale.py
+++ b/libzapi/domain/models/ticketing/locale.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from libzapi.domain.shared_objects.logical_key import LogicalKey
+
+
+@dataclass(frozen=True, slots=True)
+class Locale:
+    id: int
+    locale: str
+    name: str
+    url: Optional[str] = None
+    native_name: Optional[str] = None
+    presentation_name: Optional[str] = None
+    rtl: bool = False
+    default: bool = False
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    @property
+    def logical_key(self) -> LogicalKey:
+        return LogicalKey("locale", self.locale.lower().replace("-", "_"))

--- a/libzapi/infrastructure/api_clients/ticketing/__init__.py
+++ b/libzapi/infrastructure/api_clients/ticketing/__init__.py
@@ -9,6 +9,7 @@ from libzapi.infrastructure.api_clients.ticketing.group_membership_api_client im
     GroupMembershipApiClient,
 )
 from libzapi.infrastructure.api_clients.ticketing.job_status_api_client import JobStatusApiClient
+from libzapi.infrastructure.api_clients.ticketing.locale_api_client import LocaleApiClient
 from libzapi.infrastructure.api_clients.ticketing.macro_api_client import MacroApiClient
 from libzapi.infrastructure.api_clients.ticketing.organization_api_client import OrganizationApiClient
 from libzapi.infrastructure.api_clients.ticketing.organization_membership_api_client import (
@@ -49,6 +50,7 @@ __all__ = [
     "GroupApiClient",
     "GroupMembershipApiClient",
     "JobStatusApiClient",
+    "LocaleApiClient",
     "MacroApiClient",
     "OrganizationApiClient",
     "OrganizationMembershipApiClient",

--- a/libzapi/infrastructure/api_clients/ticketing/locale_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/locale_api_client.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+from urllib.parse import urlencode
+
+from libzapi.domain.models.ticketing.locale import Locale
+from libzapi.infrastructure.http.client import HttpClient
+from libzapi.infrastructure.http.pagination import yield_items
+from libzapi.infrastructure.serialization.parse import to_domain
+
+
+class LocaleApiClient:
+    """HTTP adapter for Zendesk Locales."""
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def list_all(self) -> Iterator[Locale]:
+        yield from self._list("/api/v2/locales")
+
+    def list_agent(self) -> Iterator[Locale]:
+        yield from self._list("/api/v2/locales/agent")
+
+    def list_public(self) -> Iterator[Locale]:
+        yield from self._list("/api/v2/locales/public")
+
+    def get(self, locale_id_or_code: int | str) -> Locale:
+        data = self._http.get(f"/api/v2/locales/{locale_id_or_code}")
+        return to_domain(data=data["locale"], cls=Locale)
+
+    def get_current(self) -> Locale:
+        data = self._http.get("/api/v2/locales/current")
+        return to_domain(data=data["locale"], cls=Locale)
+
+    def detect_best(self, available: Iterable[str]) -> Locale:
+        codes = ",".join(available)
+        path = f"/api/v2/locales/detect_best_locale?{urlencode({'available': codes})}"
+        data = self._http.get(path)
+        return to_domain(data=data["locale"], cls=Locale)
+
+    def _list(self, path: str) -> Iterator[Locale]:
+        for obj in yield_items(
+            get_json=self._http.get,
+            first_path=path,
+            base_url=self._http.base_url,
+            items_key="locales",
+        ):
+            yield to_domain(data=obj, cls=Locale)

--- a/tests/integration/ticketing/test_locales.py
+++ b/tests/integration/ticketing/test_locales.py
@@ -1,0 +1,19 @@
+import itertools
+
+from libzapi import Ticketing
+
+
+def test_list_all(ticketing: Ticketing):
+    items = list(itertools.islice(ticketing.locales.list_all(), 20))
+    assert isinstance(items, list)
+
+
+def test_list_public(ticketing: Ticketing):
+    items = list(itertools.islice(ticketing.locales.list_public(), 20))
+    assert isinstance(items, list)
+
+
+def test_get_current(ticketing: Ticketing):
+    locale = ticketing.locales.get_current()
+    assert locale.id is not None
+    assert locale.locale

--- a/tests/unit/ticketing/test_locale.py
+++ b/tests/unit/ticketing/test_locale.py
@@ -1,0 +1,85 @@
+import pytest
+
+from libzapi.domain.errors import NotFound, RateLimited, Unauthorized
+from libzapi.infrastructure.api_clients.ticketing import LocaleApiClient
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.locale_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+@pytest.mark.parametrize(
+    "method, path",
+    [
+        ("list_all", "/api/v2/locales"),
+        ("list_agent", "/api/v2/locales/agent"),
+        ("list_public", "/api/v2/locales/public"),
+    ],
+)
+def test_list_endpoints_hit_expected_path(method, path, http, domain):
+    http.get.return_value = {"locales": [{"id": 1}]}
+    client = LocaleApiClient(http)
+    items = list(getattr(client, method)())
+    assert len(items) == 1
+    assert items[0]["_cls"] == "Locale"
+    http.get.assert_called_with(path)
+
+
+def test_get_by_id(http, domain):
+    http.get.return_value = {"locale": {"id": 1}}
+    client = LocaleApiClient(http)
+    result = client.get(1)
+    assert result["_cls"] == "Locale"
+    http.get.assert_called_with("/api/v2/locales/1")
+
+
+def test_get_by_code(http, domain):
+    http.get.return_value = {"locale": {"id": 1}}
+    client = LocaleApiClient(http)
+    result = client.get("en-US")
+    assert result["_cls"] == "Locale"
+    http.get.assert_called_with("/api/v2/locales/en-US")
+
+
+def test_get_current(http, domain):
+    http.get.return_value = {"locale": {"id": 1}}
+    client = LocaleApiClient(http)
+    result = client.get_current()
+    assert result["_cls"] == "Locale"
+    http.get.assert_called_with("/api/v2/locales/current")
+
+
+def test_detect_best(http, domain):
+    http.get.return_value = {"locale": {"id": 1}}
+    client = LocaleApiClient(http)
+    result = client.detect_best(["en-US", "pt-BR"])
+    assert result["_cls"] == "Locale"
+    http.get.assert_called_with(
+        "/api/v2/locales/detect_best_locale?available=en-US%2Cpt-BR"
+    )
+
+
+@pytest.mark.parametrize("error_cls", [Unauthorized, NotFound, RateLimited])
+def test_raises_on_http_error(error_cls, http):
+    http.get.side_effect = error_cls("error")
+    client = LocaleApiClient(http)
+    with pytest.raises(error_cls):
+        list(client.list_all())
+
+
+def test_locale_logical_key():
+    from libzapi.domain.models.ticketing.locale import Locale
+
+    locale = Locale(id=1, locale="en-US", name="English (US)")
+    assert locale.logical_key.as_str() == "locale:en_us"

--- a/tests/unit/ticketing/test_locales_service.py
+++ b/tests/unit/ticketing/test_locales_service.py
@@ -1,0 +1,50 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.services.ticketing.locales_service import LocalesService
+from libzapi.domain.errors import Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return LocalesService(client), client
+
+
+class TestDelegation:
+    def test_list_all_delegates(self):
+        service, client = _make_service()
+        client.list_all.return_value = sentinel.items
+        assert service.list_all() is sentinel.items
+        client.list_all.assert_called_once_with()
+
+    def test_list_agent_delegates(self):
+        service, client = _make_service()
+        service.list_agent()
+        client.list_agent.assert_called_once_with()
+
+    def test_list_public_delegates(self):
+        service, client = _make_service()
+        service.list_public()
+        client.list_public.assert_called_once_with()
+
+    def test_get_delegates(self):
+        service, client = _make_service()
+        service.get(1)
+        client.get.assert_called_once_with(locale_id_or_code=1)
+
+    def test_get_current_delegates(self):
+        service, client = _make_service()
+        service.get_current()
+        client.get_current.assert_called_once_with()
+
+    def test_detect_best_delegates(self):
+        service, client = _make_service()
+        service.detect_best(["en-US"])
+        client.detect_best.assert_called_once_with(available=["en-US"])
+
+
+def test_propagates_unauthorized():
+    service, client = _make_service()
+    client.list_all.side_effect = Unauthorized("x")
+    with pytest.raises(Unauthorized):
+        service.list_all()


### PR DESCRIPTION
## Summary
- Add `Locale` domain model.
- Add `LocaleApiClient` with `list_all`, `list_agent`, `list_public`, `get` (by id or code), `get_current`, and `detect_best`.
- Add `LocalesService` and wire it into the `Ticketing` facade as `ticketing.locales`.
- 100% unit coverage.

Part of #79 (Batch 3).

## Test plan
- [x] Unit: `test_locale.py`, `test_locales_service.py` — 18 passed, 100% coverage
- [x] Full unit suite — 2445 passed
- [ ] Integration smoke on a live tenant via `tests/integration/ticketing/test_locales.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)