### PR TITLE
feat(ticketing): add zendesk public ips endpoint

### DIFF
--- a/libzapi/application/services/ticketing/__init__.py
+++ b/libzapi/application/services/ticketing/__init__.py
@@ -36,6 +36,7 @@ from libzapi.application.services.ticketing.user_fields_service import UserField
 from libzapi.application.services.ticketing.user_identities_service import UserIdentitiesService
 from libzapi.application.services.ticketing.views_service import ViewsService
 from libzapi.application.services.ticketing.workspace_service import WorkspaceService
+from libzapi.application.services.ticketing.zendesk_ips_service import ZendeskIPsService
 from libzapi.infrastructure.http.auth import oauth_headers, api_token_headers
 from libzapi.infrastructure.http.client import HttpClient
 
@@ -90,3 +91,4 @@ class Ticketing:
         self.user_identities = UserIdentitiesService(api.UserIdentityApiClient(http))
         self.views = ViewsService(api.ViewApiClient(http))
         self.workspaces = WorkspaceService(api.WorkspaceApiClient(http))
+        self.zendesk_ips = ZendeskIPsService(api.ZendeskIPApiClient(http))

--- a/libzapi/application/services/ticketing/zendesk_ips_service.py
+++ b/libzapi/application/services/ticketing/zendesk_ips_service.py
@@ -1,0 +1,12 @@
+from libzapi.domain.models.ticketing.zendesk_ip import ZendeskIPs
+from libzapi.infrastructure.api_clients.ticketing.zendesk_ip_api_client import ZendeskIPApiClient
+
+
+class ZendeskIPsService:
+    """High-level service using the API client."""
+
+    def __init__(self, client: ZendeskIPApiClient) -> None:
+        self._client = client
+
+    def get_current(self) -> ZendeskIPs:
+        return self._client.get()

--- a/libzapi/domain/models/ticketing/zendesk_ip.py
+++ b/libzapi/domain/models/ticketing/zendesk_ip.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass(frozen=True, slots=True)
+class ZendeskIPs:
+    project: Optional[str] = None
+    egress_ips: List[str] = field(default_factory=list)
+    ingress_ips: List[str] = field(default_factory=list)
+    app_id: Optional[str] = None

--- a/libzapi/infrastructure/api_clients/ticketing/__init__.py
+++ b/libzapi/infrastructure/api_clients/ticketing/__init__.py
@@ -38,6 +38,7 @@ from libzapi.infrastructure.api_clients.ticketing.user_field_api_client import U
 from libzapi.infrastructure.api_clients.ticketing.user_identity_api_client import UserIdentityApiClient
 from libzapi.infrastructure.api_clients.ticketing.view_api_client import ViewApiClient
 from libzapi.infrastructure.api_clients.ticketing.workspace_api_client import WorkspaceApiClient
+from libzapi.infrastructure.api_clients.ticketing.zendesk_ip_api_client import ZendeskIPApiClient
 
 __all__ = [
     "AccountSettingsApiClient",
@@ -74,4 +75,5 @@ __all__ = [
     "UserIdentityApiClient",
     "ViewApiClient",
     "WorkspaceApiClient",
+    "ZendeskIPApiClient",
 ]

--- a/libzapi/infrastructure/api_clients/ticketing/zendesk_ip_api_client.py
+++ b/libzapi/infrastructure/api_clients/ticketing/zendesk_ip_api_client.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from libzapi.domain.models.ticketing.zendesk_ip import ZendeskIPs
+from libzapi.infrastructure.http.client import HttpClient
+from libzapi.infrastructure.serialization.parse import to_domain
+
+
+class ZendeskIPApiClient:
+    """HTTP adapter for Zendesk Public IPs"""
+
+    def __init__(self, http: HttpClient) -> None:
+        self._http = http
+
+    def get(self) -> ZendeskIPs:
+        data = self._http.get("/api/v2/ips.json")
+        return to_domain(data=data, cls=ZendeskIPs)

--- a/tests/integration/ticketing/test_zendesk_ips.py
+++ b/tests/integration/ticketing/test_zendesk_ips.py
@@ -1,0 +1,8 @@
+from libzapi import Ticketing
+from libzapi.domain.models.ticketing.zendesk_ip import ZendeskIPs
+
+
+def test_get_current_zendesk_ips(ticketing: Ticketing):
+    ips = ticketing.zendesk_ips.get_current()
+    assert isinstance(ips, ZendeskIPs)
+    assert isinstance(ips.project, str) and ips.project

--- a/tests/unit/ticketing/test_zendesk_ip.py
+++ b/tests/unit/ticketing/test_zendesk_ip.py
@@ -1,0 +1,73 @@
+import pytest
+
+from libzapi.domain.errors import NotFound, Unauthorized
+from libzapi.domain.models.ticketing.zendesk_ip import ZendeskIPs
+from libzapi.infrastructure.api_clients.ticketing import ZendeskIPApiClient
+
+
+@pytest.fixture
+def http(mocker):
+    m = mocker.Mock()
+    m.base_url = "https://example.zendesk.com"
+    return m
+
+
+@pytest.fixture
+def domain(mocker):
+    return mocker.patch(
+        "libzapi.infrastructure.api_clients.ticketing.zendesk_ip_api_client.to_domain",
+        side_effect=lambda data, cls: {"_cls": cls.__name__, **(data or {})},
+    )
+
+
+def test_get_calls_ips_endpoint(http, domain):
+    http.get.return_value = {
+        "project": "pod_eu_west_1",
+        "egress_ips": ["1.1.1.1", "2.2.2.2"],
+        "ingress_ips": ["3.3.3.3"],
+        "app_id": "support",
+    }
+    client = ZendeskIPApiClient(http)
+    result = client.get()
+    http.get.assert_called_once_with("/api/v2/ips.json")
+    domain.assert_called_once_with(
+        data={
+            "project": "pod_eu_west_1",
+            "egress_ips": ["1.1.1.1", "2.2.2.2"],
+            "ingress_ips": ["3.3.3.3"],
+            "app_id": "support",
+        },
+        cls=ZendeskIPs,
+    )
+    assert result["_cls"] == "ZendeskIPs"
+    assert result["project"] == "pod_eu_west_1"
+
+
+def test_get_passes_empty_payload_to_domain(http, domain):
+    http.get.return_value = {}
+    client = ZendeskIPApiClient(http)
+    result = client.get()
+    domain.assert_called_once_with(data={}, cls=ZendeskIPs)
+    assert result["_cls"] == "ZendeskIPs"
+
+
+@pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+def test_get_propagates_error(error_cls, http):
+    http.get.side_effect = error_cls("boom")
+    client = ZendeskIPApiClient(http)
+    with pytest.raises(error_cls):
+        client.get()
+
+
+def test_domain_dataclass_defaults():
+    ips = ZendeskIPs()
+    assert ips.project is None
+    assert ips.egress_ips == []
+    assert ips.ingress_ips == []
+    assert ips.app_id is None
+
+
+def test_domain_dataclass_is_frozen():
+    ips = ZendeskIPs(project="pod_x")
+    with pytest.raises(Exception):
+        ips.project = "pod_y"  # type: ignore[misc]

--- a/tests/unit/ticketing/test_zendesk_ips_service.py
+++ b/tests/unit/ticketing/test_zendesk_ips_service.py
@@ -1,0 +1,25 @@
+import pytest
+from unittest.mock import Mock, sentinel
+
+from libzapi.application.services.ticketing.zendesk_ips_service import ZendeskIPsService
+from libzapi.domain.errors import NotFound, Unauthorized
+
+
+def _make_service(client=None):
+    client = client or Mock()
+    return ZendeskIPsService(client), client
+
+
+def test_get_current_delegates_to_client():
+    service, client = _make_service()
+    client.get.return_value = sentinel.ips
+    assert service.get_current() is sentinel.ips
+    client.get.assert_called_once_with()
+
+
+@pytest.mark.parametrize("error_cls", [Unauthorized, NotFound])
+def test_get_current_propagates_error(error_cls):
+    service, client = _make_service()
+    client.get.side_effect = error_cls("boom")
+    with pytest.raises(error_cls):
+        service.get_current()


### PR DESCRIPTION
## Summary
- Adds `GET /api/v2/ips.json` support for discovering Zendesk's public egress/ingress IP ranges
- New `ZendeskIPs` domain model, `ZendeskIPApiClient`, and `ZendeskIPsService`
- Exposed on the `Ticketing` facade as `ticketing.zendesk_ips`
- 100% unit coverage on all new modules; integration test hits the live endpoint

Part of #79.

## Test plan
- [x] Unit tests pass (`pytest tests/unit`)
- [x] 100% coverage on new domain/client/service modules
- [ ] Integration test (`tests/integration/ticketing/test_zendesk_ips.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)